### PR TITLE
Upgrade mac taskcluster workers to generic worker 10.8.4

### DIFF
--- a/modules/generic_worker/manifests/init.pp
+++ b/modules/generic_worker/manifests/init.pp
@@ -7,6 +7,7 @@ class generic_worker {
 
     case $::operatingsystem {
         Darwin: {
+            $taskcluster_host = 'taskcluster'
             $macos_version = regsubst($::macosx_productversion_major, '\.', '')
             $taskcluster_client_id = secret('generic_worker_macosx_client_id')
             $taskcluster_access_token = hiera('generic_worker_macosx_access_token')
@@ -39,6 +40,20 @@ class generic_worker {
                     File['/Library/LaunchAgents/net.generic.worker.plist'],
                 ],
                 enable  => true;
+            }
+            exec { 'create gpg key':
+                path    => ['/bin', '/sbin', '/usr/local/bin'],
+                user    => 'cltbld',
+                command => 'generic-worker new-openpgp-keypair --file /Users/cltbld/generic-worker.openpgp.key',
+                unless  => 'test -f /Users/cltbld/generic-worker.openpgp.key'
+            }
+            host {"${taskcluster_host}":
+                ip => '127.0.0.1'
+            }
+
+            httpd::config {
+                'proxy.conf':
+                    content => template('generic_worker/proxy-httpd.conf.erb');
             }
         }
         default: {

--- a/modules/generic_worker/templates/generic-worker.config.erb
+++ b/modules/generic_worker/templates/generic-worker.config.erb
@@ -28,6 +28,8 @@
   "sentryProject": "generic-worker",
   "shutdownMachineOnIdle": false,
   "shutdownMachineOnInternalError": false,
+  "taskclusterProxyExecutable": "/usr/local/bin/taskcluster-proxy",
+  "taskclusterProxyPort": 8080,
   "signingKeyLocation": "/Users/cltbld/generic-worker.openpgp.key",
   "subdomain": "taskcluster-worker.net",
   "tasksDir": "/Users/cltbld/tasks",

--- a/modules/generic_worker/templates/proxy-httpd.conf.erb
+++ b/modules/generic_worker/templates/proxy-httpd.conf.erb
@@ -1,0 +1,10 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+<%# License, v. 2.0. If a copy of the MPL was not distributed with this
+<%# file, You can obtain one at http://mozilla.org/MPL/2.0/. -%>
+
+<VirtualHost <%= @taskcluster_host %>:80>
+    ProxyPreserveHost On
+    ProxyPass / http://<%= @taskcluster_host %>:8080/
+    ProxyPassReverse / http://<%= @taskcluster_host %>:8080/
+    ServerName <%= @taskcluster_host %>
+</VirtualHost>

--- a/modules/packages/manifests/mozilla/generic_worker.pp
+++ b/modules/packages/manifests/mozilla/generic_worker.pp
@@ -8,7 +8,8 @@ class packages::mozilla::generic_worker {
         'packages::mozilla::generic_worker::end': ;
     }
 
-    $tag = 'v10.2.3'
+    $tag = 'v10.8.4'
+    $proxy_tag = 'v4.1.1'
 
     # Binaries should be downloaded from
     # https://github.com/taskcluster/generic-worker/releases/download/${tag}/generic-worker-${os}-${arch}
@@ -20,6 +21,14 @@ class packages::mozilla::generic_worker {
             file {
                 '/usr/local/bin/generic-worker':
                     source => "puppet:///repos/EXEs/generic-worker-${tag}-darwin-amd64",
+                    mode   => '0755',
+                    owner  => root,
+                    group  => wheel,
+            }
+            # install taskcluster proxy, Bug 1452095
+            file {
+                '/usr/local/bin/taskcluster-proxy':
+                    source => "puppet:///repos/EXEs/taskcluster-proxy-${proxy_tag}-darwin-amd64",
                     mode   => '0755',
                     owner  => root,
                     group  => wheel,


### PR DESCRIPTION
- changed the generic-worker version
- added version tag for tasckcluster-proxy
- Added an exect block to generate generic-worker signingKey
- changed generic-worker config file by add information for tasckcluster-proxy
- installed tasck-cluster proxy on /usr/local/bin location
- added proxy httpd file, to redirect curl http://taskcluster to port 8080 (taskcluster-proxy listen on this port)