### PR TITLE
Rewrite puppet manifest locations to the mozilla-releng org on Github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 See https://wiki.mozilla.org/ReleaseEngineering/PuppetAgain.
 
-[![Build Status](https://travis-ci.org/mozilla/build-puppet.png)](https://travis-ci.org/mozilla/build-puppet)
+[![Build Status](https://travis-ci.org/mozilla-releng/build-puppet.png)](https://travis-ci.org/mozilla-releng/build-puppet)
 
 License
 =======

--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -103,7 +103,7 @@ class config inherits config::base {
     # See https://bugzilla.mozilla.org/show_bug.cgi?id=906785
     $apt_repo_server            = 'puppetagain-apt.pvt.build.mozilla.org'
     $distinguished_puppetmaster = 'releng-puppet2.srv.releng.scl3.mozilla.com'
-    $puppet_again_repo          = 'https://github.com/mozilla/build-puppet'
+    $puppet_again_repo          = 'https://github.com/mozilla-releng/build-puppet'
     $puppetmaster_extsyncs      = {
         'slavealloc' => {
             'slavealloc_api_url' => 'http://slavealloc.pvt.build.mozilla.org/api/',

--- a/modules/config/manifests/base.pp
+++ b/modules/config/manifests/base.pp
@@ -25,7 +25,7 @@ class config::base {
 
     # The repository and branch that puppetmasters should follow to get the latest
     # manifests
-    $puppet_again_repo              = 'https://github.com/mozilla/build-puppet'
+    $puppet_again_repo              = 'https://github.com/mozilla-releng/build-puppet'
     $puppet_again_branch            = 'master'
 
     # The fqdn of the 'distinguished' puppetmaster.  This master serves as the

--- a/modules/generic_worker/templates/generic-worker.config.erb
+++ b/modules/generic_worker/templates/generic-worker.config.erb
@@ -36,7 +36,7 @@
   "workerType": "gecko-t-osx-<%= @macos_version %>",
   "workerTypeMetadata": {
     "machine-setup": {
-      "config": "https://hg.mozilla.org/build/puppet/raw-file/production/modules/generic_worker/templates/generic-worker.config.erb",
+      "config": "https://github.com/mozilla-releng/build-puppet/raw/master/modules/generic_worker/templates/generic-worker.config.erb",
       "docs": "https://wiki.mozilla.org/ReleaseEngineering/PuppetAgain/Modules/generic_worker"
     }
   }

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -49,19 +49,6 @@ mkdir -p "${SEMAPHORE_DIR}"
 chmod 0777 "${SEMAPHORE_DIR}"
 rm -rf "${SEMAPHORE}"
 
-function puppet_config_version_is_not_latest() {
-    readonly local last_run_summary_yml=/var/lib/puppet/state/last_run_summary.yaml
-    local last_run=$(sed -n -e 's/^[ \n\t]*config:[ \n\t]*"\([^+"]*\)+*"/\1/p' "${last_run_summary_yml}")
-    # if git fails or is not yet installed, this will leave a non-matching empty string
-    # FIXME: since the move to github, last_run is always "remotes/origin/HEAD" because of the way
-    # we checkout the manifests on the masters, so this check is not doing anything
-    #local repo_version=$(git ls-remote -h https://github.com/mozilla-releng/build-puppet | grep master | awk '{print $1}')
-    local repo_version=""
-    echo "Last puppet run (config version): ${last_run} [Repository tip hash: ${repo_version}]"
-    [[ -z "${repo_version}" ]] && return 1
-    [[ "${last_run}" != "${repo_version}" ]]
-}
-
 function puppet_elapsed_time_exceeded() {
     local max_seconds=<%= scope['::config::puppet_run_atboot_if_more_than_seconds'] %>
 
@@ -95,8 +82,7 @@ wait_for_dns
 if <%= @puppet_run_atboot_always %> \
    || [ -f $REBOOT_FLAG_FILE ] \
    || cause=$(puppet_reboot_counter_exceeded) \
-   || cause=$(puppet_elapsed_time_exceeded) \
-   || cause=$(puppet_config_version_is_not_latest); then
+   || cause=$(puppet_elapsed_time_exceeded); then
     logger -ist run-puppet "Starting run-puppet.sh at $(date). ${cause}"
     > $REBOOT_COUNT_FILE  # reset reboot count
     run_until_success

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -56,7 +56,7 @@ function puppet_config_version_is_not_latest() {
     # FIXME: since the move to github, last_run is always "remotes/origin/HEAD" because of the way
     # we checkout the manifests on the masters, so this check is not doing anything
     #local repo_version=$(git ls-remote -h https://github.com/mozilla-releng/build-puppet | grep master | awk '{print $1}')
-    local repo_version="remotes/origin/HEAD"
+    local repo_version=""
     echo "Last puppet run (config version): ${last_run} [Repository tip hash: ${repo_version}]"
     [[ -z "${repo_version}" ]] && return 1
     [[ "${last_run}" != "${repo_version}" ]]

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -52,8 +52,11 @@ rm -rf "${SEMAPHORE}"
 function puppet_config_version_is_not_latest() {
     readonly local last_run_summary_yml=/var/lib/puppet/state/last_run_summary.yaml
     local last_run=$(sed -n -e 's/^[ \n\t]*config:[ \n\t]*"\([^+"]*\)+*"/\1/p' "${last_run_summary_yml}")
-    # if hg fails or is not yet installed, this will leave a non-matching empty string
-    local repo_version=$(hg identify https://hg.mozilla.org/build/puppet)
+    # if git fails or is not yet installed, this will leave a non-matching empty string
+    # FIXME: since the move to github, last_run is always "remotes/origin/HEAD" because of the way
+    # we checkout the manifests on the masters, so this check is not doing anything
+    #local repo_version=$(git ls-remote -h https://github.com/mozilla-releng/build-puppet | grep master | awk '{print $1}')
+    local repo_version="remotes/origin/HEAD"
     echo "Last puppet run (config version): ${last_run} [Repository tip hash: ${repo_version}]"
     [[ -z "${repo_version}" ]] && return 1
     [[ "${last_run}" != "${repo_version}" ]]

--- a/setup/common/install-puppetize.erb
+++ b/setup/common/install-puppetize.erb
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # set up the puppetize script to run at boot
-hgrepo="https://hg.mozilla.org/build/puppet"
-wget -O/root/puppetize.sh "$hgrepo/raw-file/default/modules/puppet/files/puppetize.sh" || fail
+gitrepo="https://github.com/mozilla-releng/build-puppet"
+wget -O/root/puppetize.sh "$gitrepo/raw/master/modules/puppet/files/puppetize.sh" || fail
 chmod +x /root/puppetize.sh
 (
     grep -v puppetize /etc/rc.d/rc.local

--- a/setup/preseed/preseed_to_puppet.sh
+++ b/setup/preseed/preseed_to_puppet.sh
@@ -48,11 +48,11 @@ echo "$PUPPET_PASS" > /root/deploypass
 chmod 600 /root/deploypass
 
 # set up the puppetize script to run at boot
-hgrepo="https://hg.mozilla.org/build/puppet"
+gitrepo="https://github.com/mozilla-releng/build-puppet"
 # try to use the proxy, falling back to a direct fetch (e.g., if the DC doesn't have a proxy)
-https_proxy=https://proxy.dmz.mdc2.mozilla.com:3128/ wget --tries=3 --waitretry=10 -O/root/puppetize.sh "$hgrepo/raw-file/default/modules/puppet/files/puppetize.sh" \
-    || https_proxy=https://proxy.dmz.mdc1.mozilla.com:3128/ wget --tries=3 --waitretry=10 -O/root/puppetize.sh "$hgrepo/raw-file/default/modules/puppet/files/puppetize.sh" \
-    || wget --tries=6 --waitretry=60 -O/root/puppetize.sh "$hgrepo/raw-file/default/modules/puppet/files/puppetize.sh" \
+https_proxy=https://proxy.dmz.mdc2.mozilla.com:3128/ wget --tries=3 --waitretry=10 -O/root/puppetize.sh "$gitrepo/raw/master/modules/puppet/files/puppetize.sh" \
+    || https_proxy=https://proxy.dmz.mdc1.mozilla.com:3128/ wget --tries=3 --waitretry=10 -O/root/puppetize.sh "$gitrepo/raw/master/modules/puppet/files/puppetize.sh" \
+    || wget --tries=6 --waitretry=60 -O/root/puppetize.sh "$gitrepo/raw/master/modules/puppet/files/puppetize.sh" \
     || fail
 chmod +x /root/puppetize.sh
 


### PR DESCRIPTION
This rewrites the remaining traces of https://hg.mozilla.org/build/puppet, and the original github location to the new, final home in the RelEng org.

@davehouse - I'm flagging you for review because of the changes to `puppet-darwin-run-puppet.sh.erb`. You'll notice that I've basically disabled the manifest version check for now. I'll need to make changes to the Puppet masters before we can enable it again. How important is that check?