### PR TITLE
bug 1467255: Add verification of requirements files in CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,8 +8,6 @@ metadata:
 tasks:
   - provisionerId: "{{ taskcluster.docker.provisionerId }}"
     workerType: "{{ taskcluster.docker.workerType }}"
-    scopes:
-      - secrets:get:repo:github.com/mozilla/balrog:coveralls
     payload:
       maxRunTime: 3600
       image: "python:2.7-slim"
@@ -34,8 +32,6 @@ tasks:
       source: "{{ event.head.repo.url }}"
   - provisionerId: "{{ taskcluster.docker.provisionerId }}"
     workerType: "{{ taskcluster.docker.workerType }}"
-    scopes:
-      - secrets:get:repo:github.com/mozilla/balrog:coveralls
     payload:
       maxRunTime: 3600
       image: "python:3.6-slim"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,60 @@
+version: 0
+allowPullRequests: public
+metadata:
+  name: PuppetAgain
+  description: PuppetAgain CI Tasks
+  owner: "{{ event.head.user.email }}"
+  source: "{{ event.head.repo.url }}"
+tasks:
+  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    scopes:
+      - secrets:get:repo:github.com/mozilla/balrog:coveralls
+    payload:
+      maxRunTime: 3600
+      image: "python:2.7-slim"
+      command:
+        - "/bin/bash"
+        - "-c"
+        - "git clone $GITHUB_HEAD_REPO_URL build-puppet && cd build-puppet && bash test/verify-requirements.sh 27"
+    extra:
+      github:
+        env: true
+        events:
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
+          - push
+        branches:
+          - master
+    metadata:
+      name: PuppetAgain Python 2.7 requirements
+      description: PuppetAgain Python 2.7 requirements file verification
+      owner: "{{ event.head.user.email }}"
+      source: "{{ event.head.repo.url }}"
+  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    scopes:
+      - secrets:get:repo:github.com/mozilla/balrog:coveralls
+    payload:
+      maxRunTime: 3600
+      image: "python:3.6-slim"
+      command:
+        - "/bin/bash"
+        - "-c"
+        - "git clone $GITHUB_HEAD_REPO_URL build-puppet && cd build-puppet && bash test/verify-requirements.sh 36"
+    extra:
+      github:
+        env: true
+        events:
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
+          - push
+        branches:
+          - master
+    metadata:
+      name: PuppetAgain Python 2.7 requirements
+      description: PuppetAgain Python 2.7 requirements file verification
+      owner: "{{ event.head.user.email }}"
+      source: "{{ event.head.repo.url }}"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -14,7 +14,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL build-puppet && cd build-puppet && bash test/verify-requirements.sh 27"
+        - "git clone $GITHUB_HEAD_REPO_URL build-puppet && cd build-puppet && git checkout $GITHUB_HEAD_BRANCH && bash test/verify-requirements.sh 27"
     extra:
       github:
         env: true
@@ -38,7 +38,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL build-puppet && cd build-puppet && bash test/verify-requirements.sh 36"
+        - "git clone $GITHUB_HEAD_REPO_URL build-puppet && cd build-puppet && git checkout $GITHUB_HEAD_BRANCH && bash test/verify-requirements.sh 36"
     extra:
       github:
         env: true
@@ -50,7 +50,7 @@ tasks:
         branches:
           - master
     metadata:
-      name: PuppetAgain Python 2.7 requirements
-      description: PuppetAgain Python 2.7 requirements file verification
+      name: PuppetAgain Python 3.6 requirements
+      description: PuppetAgain Python 3.6 requirements file verification
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"

--- a/modules/aws_manager/files/requirements.txt
+++ b/modules/aws_manager/files/requirements.txt
@@ -18,7 +18,7 @@ ssh==1.8.0
 wsgiref==0.1.2
 docopt==0.6.2
 netaddr==0.7.19
-cfn-pyplates>=0.5.0
+cfn-pyplates==0.6.0
 PyYAML==3.12
 dnspython==1.15.0
 testrepository==0.0.20
@@ -51,3 +51,9 @@ chardet==3.0.4
 certifi==2018.4.16
 ipaddress==1.0.22
 enum34==1.1.6
+fixtures==3.0.0
+python-mimeparse==1.6.0
+unittest2==1.1.0
+traceback2==1.4.0
+pycparser==2.18
+linecache2==1.0.0

--- a/modules/buildbot_bridge2/files/requirements.txt
+++ b/modules/buildbot_bridge2/files/requirements.txt
@@ -12,6 +12,7 @@ jsonschema==2.6.0
 mohawk==0.3.4
 multidict==4.3.0
 mysql-connector-python==8.0.11
+protobuf==3.5.2.post1
 py==1.5.3
 pyparsing==2.2.0
 python-dateutil==2.7.3

--- a/modules/buildduty_tools/files/requirements.txt
+++ b/modules/buildduty_tools/files/requirements.txt
@@ -5,8 +5,17 @@ Jinja2==2.10
 MarkupSafe==1.0
 Twisted==18.4.0
 argparse==1.4.0
+asn1crypto==0.24.0
+attrs==18.1.0
+automat==0.6.0
 cffi==1.11.5
+constantly==15.1.0
 cryptography==2.2.2
+enum34==1.1.6
+hyperlink==18.0.0
+idna==2.6
+incremental==17.5.0
+ipaddress==1.0.22
 pyOpenSSL==18.0.0
 pyasn1==0.4.3
 pycparser==2.18

--- a/modules/cruncher/files/slave_health_requirements.txt
+++ b/modules/cruncher/files/slave_health_requirements.txt
@@ -1,9 +1,13 @@
 # python_version: 27
 MySQL-python==1.2.5
 SQLAlchemy==1.2.8
+certifi==2018.4.16
+chardet==3.0.4
+idna==2.6
 pytz==2018.4
 # Pinning to avoid investigating if an update would break
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1289822#c7
 requests==2.18.4
 simplejson==3.15.0
+urllib3==1.22
 wsgiref==0.1.2

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -24,13 +24,17 @@ cryptography==2.2.2
 decorator==4.2.1
 ecdsa==0.13
 enum34==1.1.6
+future==0.16.0
 futures==3.2.0
 idna==2.6
 invoke==1.0.0
 ipaddress==1.0.22
+MarkupSafe==1.0
 mohawk==0.3.4
 paramiko==2.4.1
+pbr==4.0.4
 pyasn1==0.4.3
+pycparser==2.18
 pycrypto==2.6.1
 pynacl==1.2.1
 python-dateutil==2.7.3
@@ -39,10 +43,12 @@ redo==1.6
 releasetasks==0.4.1  # puppet: nodownload
 requests==2.18.4
 requests-hawk==1.0.0
+rsa==3.4.2
 simplejson==3.15.0
 singledispatch==3.4.0.3
 slugid==1.0.7
 sqlalchemy-migrate==0.11.0
+sqlparse==0.2.4
 # Held at this ancient version because we need encrypted enviroment variable support.
 taskcluster==0.0.24  # pyup: noupdate
 toposort==1.5

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -1,7 +1,7 @@
 # python_version: 27
 # install six before cryptography
 # held at old version because 1.11.0 breaks pgpy
-six==1.10.0  # pyup: ignore
+six==1.15.0  # pyup: ignore
 Fabric==2.1.3
 Jinja2==2.10
 PGPy==0.4.3

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -15,7 +15,7 @@ arrow==0.12.1
 asn1crypto==0.24.0
 backports.functools_lru_cache==1.5
 bcrypt==3.1.4
-#buildbot==0.8.7p1  # pyup: ignore, puppet: nodownload
+buildbot==0.8.7p1  # pyup: ignore, puppet: nodownload
 certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
@@ -36,7 +36,7 @@ pynacl==1.2.1
 python-dateutil==2.7.3
 python-jose==3.0.0
 redo==1.6
-#releasetasks==0.4.1  # puppet: nodownload
+releasetasks==0.4.1  # puppet: nodownload
 requests==2.18.4
 requests-hawk==1.0.0
 simplejson==3.15.0

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -1,7 +1,7 @@
 # python_version: 27
 # install six before cryptography
 # held at old version because 1.11.0 breaks pgpy
-six==1.15.0  # pyup: ignore
+six==1.10.0  # pyup: ignore
 Fabric==2.1.3
 Jinja2==2.10
 PGPy==0.4.3
@@ -15,7 +15,7 @@ arrow==0.12.1
 asn1crypto==0.24.0
 backports.functools_lru_cache==1.5
 bcrypt==3.1.4
-buildbot==0.8.7p1  # pyup: ignore, puppet: nodownload
+#buildbot==0.8.7p1  # pyup: ignore, puppet: nodownload
 certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
@@ -36,7 +36,7 @@ pynacl==1.2.1
 python-dateutil==2.7.3
 python-jose==3.0.0
 redo==1.6
-releasetasks==0.4.1  # puppet: nodownload
+#releasetasks==0.4.1  # puppet: nodownload
 requests==2.18.4
 requests-hawk==1.0.0
 simplejson==3.15.0

--- a/modules/selfserve_agent/files/requirements.txt
+++ b/modules/selfserve_agent/files/requirements.txt
@@ -14,6 +14,7 @@ amqp==2.3.2
 buildapi==0.3.25  # puppet: nodownload
 buildbot==0.8.4-pre-moz2  # pyup: ignore, puppet: nodownload
 decorator==4.2.1
+funcsigs==1.0.2
 kombu==4.2.1
 Routes==2.4.1
 SQLAlchemy==1.2.8
@@ -24,11 +25,15 @@ WebError==0.13.1
 WebHelpers==1.3
 WebOb==1.8.1
 WebTest==2.0.29
+beautifulsoup4==4.6.0
 meld3==1.0.2
 nose==1.3.7
 pytz==2018.4
 redis==2.10.6
+repoze.lru==0.7
 simplejson==3.15.0
+six==1.11.0
 wsgiref==0.1.2
-zope.interface==4.5.0
 vine==1.1.4
+waitress==1.1.0
+zope.interface==4.5.0

--- a/modules/signingworker/files/requirements.txt
+++ b/modules/signingworker/files/requirements.txt
@@ -11,6 +11,7 @@ configman==1.3.0
 configobj==5.0.6
 ecdsa==0.13
 functools32==3.2.3-2
+future==0.16.0
 idna==2.6
 jsonschema==2.6.0
 kombu==4.2.1
@@ -28,6 +29,7 @@ signingworker==0.15
 six==1.11.0
 slugid==1.0.7
 taskcluster==3.0.1
+total-ordering==0.1.0
 wsgiref==0.1.2
 vine==1.1.4
 urllib3==1.22

--- a/modules/slaveapi/files/requirements.txt
+++ b/modules/slaveapi/files/requirements.txt
@@ -24,8 +24,9 @@ python-dateutil==2.7.3
 MySQL-python==1.2.5
 PyYAML==3.12
 SQLAlchemy==1.2.8
-cfn-pyplates>=0.5.0
+cfn-pyplates==0.6.0
 ecdsa==0.13
+idna==2.6
 invtool==4.4  # puppet: nodownload
 netaddr==0.7.19
 ordereddict==1.1
@@ -43,4 +44,26 @@ boto==2.48.0
 iso8601==0.1.12
 repoze.lru==0.7
 ssh==1.8.0
+urllib3==1.22
 wsgiref==0.1.2
+certifi==2018.4.16
+chardet==3.0.4
+six==1.11.0
+cryptography==2.2.2
+pynacl==1.2.1
+pyasn1==0.4.3
+bcrypt==3.1.4
+click==6.7
+docutils==0.14
+lockfile==0.12.2
+fixtures==3.0.0
+python-mimeparse==1.6.0
+unittest2==1.1.0
+traceback2==1.4.0
+invoke==1.0.0
+cffi==1.11.5
+enum34==1.1.6
+asn1crypto==0.24.0
+ipaddress==1.0.22
+linecache2==1.0.0
+pycparser==2.18

--- a/modules/slaverebooter/files/requirements.txt
+++ b/modules/slaverebooter/files/requirements.txt
@@ -1,6 +1,24 @@
 # python_version: 27
-furl==1.0.2
-requests==2.18.4
-docopt==0.6.2
+attrs==18.1.0
+automat==0.6.0
 buildtools==1.0.6
+certifi==2018.4.16
+chardet==3.0.4
+constantly==15.1.0
+docopt==0.6.2
+furl==1.0.2
+hyperlink==18.0.0
+idna==2.6
+incremental==17.5.0
+jinja2==2.10
+markupsafe==1.0
 orderedmultidict==0.7.11
+python-dateutil==2.7.3
+redo==1.6
+requests==2.18.4
+simplejson==3.15.0
+six==1.11.0
+sqlalchemy==1.2.8
+twisted==18.4.0
+urllib3==1.22
+zope.interface==4.5.0

--- a/modules/slaverebooter/files/requirements.txt
+++ b/modules/slaverebooter/files/requirements.txt
@@ -1,4 +1,5 @@
 # python_version: 27
+argparse==1.4.0
 attrs==18.1.0
 automat==0.6.0
 buildtools==1.0.6

--- a/test/verify-requirements.sh
+++ b/test/verify-requirements.sh
@@ -34,7 +34,7 @@ for req_file in `find ${MODULES} -wholename "*files*requirements*.txt"`; do
     venv_python="${virtualenv_dir}/bin/${python}"
     pip="${virtualenv_dir}/bin/pip"
 
-    echo "Verify requirements for ${req_file}..."
+    echo "Verifying requirements for ${req_file}..."
     while read dependency; do
         hashin -r ${pypi_deps} ${dependency}
         if [ $? != 0 ]; then

--- a/test/verify-requirements.sh
+++ b/test/verify-requirements.sh
@@ -22,6 +22,8 @@ for req_file in `find ${MODULES} -wholename "*files*requirements*.txt"`; do
         continue
     fi
 
+    echo "Verifying requirements for ${req_file}..."
+
     python=$(which python2.7)
     if [ "${req_python_version}" == "36" ]; then
         python=$(which python3.6)
@@ -34,7 +36,6 @@ for req_file in `find ${MODULES} -wholename "*files*requirements*.txt"`; do
     venv_python="${virtualenv_dir}/bin/${python}"
     pip="${virtualenv_dir}/bin/pip"
 
-    echo "Verifying requirements for ${req_file}..."
     hashin_error=0
     while read dependency; do
         hashin -r ${pypi_deps} ${dependency}

--- a/test/verify-requirements.sh
+++ b/test/verify-requirements.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MY_DIR=$(pwd)
+MY_DIR=$(dirname $(readlink -f $0))
 MODULES=$(readlink -f "${MY_DIR}/../modules")
 
 rc=0
@@ -31,7 +31,12 @@ for req_file in `find ${MODULES} -wholename "*files*requirements*.txt"`; do
     # if exit code is not 1, print message and mark overall as fail
     if [ $? != 0 ]; then
         echo "ERROR: pip install failed for ${req_file}. See below for details:"
+        echo "pip install log:"
         cat ${log}
+        echo "requirements file used:"
+        cat ${pypi_deps}
+        echo
+        echo
         rc=1
     fi
 done

--- a/test/verify-requirements.sh
+++ b/test/verify-requirements.sh
@@ -7,9 +7,9 @@ python_version=$1
 
 rc=0
 
-# We want to do everything inside the loop in virtualenvs,
-# so we install that first, with the system pip.
-pip install virtualenv
+# We need virtualenv and hashin to do our work, so we install them
+# into the system first
+pip install virtualenv hashin
 
 for req_file in `find ${MODULES} -wholename "*files*requirements*.txt"`; do
     req_python_version=$(grep python_version $req_file | cut -d: -f2 | xargs)
@@ -29,13 +29,10 @@ for req_file in `find ${MODULES} -wholename "*files*requirements*.txt"`; do
     virtualenv -p ${python} ${virtualenv_dir} >${log} 2>&1
     venv_python="${virtualenv_dir}/bin/${python}"
     pip="${virtualenv_dir}/bin/pip"
-    hashin="${virtualenv_dir}/bin/hashin"
-
-    ${pip} install hashin
 
     echo "Verify requirements for ${req_file}..."
     while read dependency; do
-        ${hashin} -r ${pypi_deps} ${dependency}
+        hashin -r ${pypi_deps} ${dependency}
         if [ $? != 0 ]; then
             echo "ERROR: couldn't find hashes for ${dependency}. The pinned version is probably invalid."
             rc=1

--- a/test/verify-requirements.sh
+++ b/test/verify-requirements.sh
@@ -7,6 +7,10 @@ python_version=$1
 
 rc=0
 
+# Install the packages we need to install certain Python packages.
+apt-get -q update
+apt-get -q --yes install gcc automake autoconf libmariadbclient-dev liblzma-dev
+
 # We need virtualenv and hashin to do our work, so we install them
 # into the system first
 pip install virtualenv hashin

--- a/test/verify-requirements.sh
+++ b/test/verify-requirements.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+MY_DIR=$(pwd)
+MODULES=$(readlink -f "${MY_DIR}/../modules")
+
+rc=0
+
+# in order to catch transitive dependencies we need hashes, so maybe try:
+# 1) parse requirements file and remove nodownload deps (beacuse they aren't on pypi)
+# 2) run the new requirements file through hashin, to add hashes
+# 3) pip install the new new requirements file, which should fail if any transitive deps are missing
+for req_file in `find ${MODULES} -wholename "*files*requirements*.txt"`; do
+    echo "Verify requirements for ${req_file}..."
+    virtualenv_dir=$(mktemp -d)
+    log=$(mktemp)
+    req_python_version=$(grep python_version $req_file | cut -d: -f2 | xargs)
+    python=$(which python2.7)
+    if [ "${req_python_version}" == "36" ]; then
+        python=$(which python3.6)
+    fi
+    virtualenv -p ${python} ${virtualenv_dir} >${log} 2>&1
+    venv_python="${virtualenv_dir}/bin/${python}"
+    pip="${virtualenv_dir}/bin/pip"
+
+    ${pip} install -r ${req_file} >>${log} 2>&1
+    # if exit code is not 1, print message and mark overall as fail
+    if [ $? != 0 ]; then
+        echo "ERROR: pip install failed for ${req_file}. See below for details:"
+        cat ${log}
+        rc=1
+    fi
+done
+
+exit ${rc}

--- a/test/verify-requirements.sh
+++ b/test/verify-requirements.sh
@@ -7,6 +7,10 @@ python_version=$1
 
 rc=0
 
+# We want to do everything inside the loop in virtualenvs,
+# so we install that first, with the system pip.
+pip install virtualenv
+
 for req_file in `find ${MODULES} -wholename "*files*requirements*.txt"`; do
     req_python_version=$(grep python_version $req_file | cut -d: -f2 | xargs)
     if [ "${req_python_version}" != "${python_version}" ]; then


### PR DESCRIPTION
This should implement the verifications suggested in https://bugzilla.mozilla.org/show_bug.cgi?id=1467255. Specifically, it:
* Adds hashes to requirements files (except the nodownload ones)
* Verifies requirements files with `pip install`.

In testing this I found a great deal of missing transitive dependencies. Evidently, they don't break anything, but they are part of the requirements so we should be installing them.

You'll notice I'm adding a .taskcluster.yml instead of adding things to .travis.yml. It didn't look like there was a great way to ensure the required system dependencies were installed in Travis, so I thought using Taskcluster + Docker would be easier - arguably we should be transitioning more stuff to Taskcluster anyways.

I wasn't able to get the Taskcluster hook working with my test repo, but I did some runs by hand:
* Python 2.7 without any bad deps: https://tools.taskcluster.net/groups/TE7BqoOZT2qCSOTWFIn4HA/tasks/TE7BqoOZT2qCSOTWFIn4HA/details
* Python 3.6 without any bad deps: https://tools.taskcluster.net/groups/Bv0ZnSM_QtGzuLp-NT3JTA/tasks/Bv0ZnSM_QtGzuLp-NT3JTA/details
* Python 2.7 with both a badly specified version, and a missing transitive dependency: https://tools.taskcluster.net/groups/YPlCnwO8Sl2g3JH4ffa2tw/tasks/YPlCnwO8Sl2g3JH4ffa2tw/details
* Python 3.6 with the same: https://tools.taskcluster.net/groups/EFzkLco1SdmoanpKf1zZow/tasks/EFzkLco1SdmoanpKf1zZow/details