### PR TITLE
Bug1457003 roller linux ssh

### DIFF
--- a/modules/fw/manifests/networks.pp
+++ b/modules/fw/manifests/networks.pp
@@ -83,10 +83,10 @@ class fw::networks {
 
     $buildduty_tools = [ '10.132.51.74/32' ] # buildduty-tools.srv.releng.usw2.mozilla.com
 
-    $roller = [ '10.49.48.75',  # roller1.srv.releng.mdc1.mozilla.com
-                '10.49.48.76',  # roller-dev1.srv.releng.mdc1.mozilla.com
-                '10.51.48.75',  # roller1.srv.releng.mdc2.mozilla.com
-                '10.51.48.76' ] # roller-dev1.srv.releng.mdc2.mozilla.com
+    $roller = [ '10.49.48.75/32',  # roller1.srv.releng.mdc1.mozilla.com
+                '10.49.48.76/32',  # roller-dev1.srv.releng.mdc1.mozilla.com
+                '10.51.48.75/32',  # roller1.srv.releng.mdc2.mozilla.com
+                '10.51.48.76/32' ] # roller-dev1.srv.releng.mdc2.mozilla.com
 
     $slaveapi = [ '10.26.48.16/32',  # slaveapi1.srv.releng.scl3.mozilla.com
                   '10.26.48.17/32' ] # slaveapi-dev1.srv.releng.scl3.mozilla.com

--- a/modules/fw/manifests/profiles/linux_taskcluster_worker.pp
+++ b/modules/fw/manifests/profiles/linux_taskcluster_worker.pp
@@ -9,6 +9,7 @@ class fw::profiles::linux_taskcluster_worker {
             include ::fw::roles::vnc_from_rejh_logging
             include ::fw::roles::ssh_from_rejh_logging
             include ::fw::roles::ssh_from_slaveapi
+            include ::fw::roles::ssh_from_roller
         }
         default:{
             # Silently skip other DCs

--- a/modules/roller/manifests/systemd.pp
+++ b/modules/roller/manifests/systemd.pp
@@ -33,6 +33,8 @@ define roller::systemd ($image_tag){
         "/etc/docker/compose/roller${environment}/ssh.key":
             ensure  => file,
             mode    => 0600,
+            owner   => 10001,
+            group   => 10001,
             content => $roller_ssh_key;
         "/etc/docker/compose/roller${environment}/ssl.key":
             ensure  => file,

--- a/modules/roller/templates/dev/docker-compose.yml.erb
+++ b/modules/roller/templates/dev/docker-compose.yml.erb
@@ -31,6 +31,8 @@ services:
     volumes:
       - /opt/rollerdev:/app
       - ./worker_config.json:/run/worker_config.json:ro
+      - ./ssh.key:/app/ssh.key
+      - tmp:/app/.ssh
     command: watch-worker-purge
 
   ssl:
@@ -43,3 +45,6 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
       - ./ssl.crt:/run/ssl.crt:ro
       - ./ssl.key:/run/ssl.key:ro
+
+volumes:
+  tmp:

--- a/modules/roller/templates/prod/docker-compose.yml.erb
+++ b/modules/roller/templates/prod/docker-compose.yml.erb
@@ -24,6 +24,8 @@ services:
       - .env
     volumes:
       - ./worker_config.json:/run/worker_config.json:ro
+      - ./ssh.key:/app/ssh.key
+      - tmp:/app/.ssh
     command: worker
 
   ssl:
@@ -36,3 +38,6 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
       - ./ssl.crt:/run/ssl.crt:ro
       - ./ssl.key:/run/ssl.key:ro
+
+volumes:
+  tmp:

--- a/modules/roller/templates/prod/env.erb
+++ b/modules/roller/templates/prod/env.erb
@@ -23,5 +23,5 @@ TASK_NAMES=ping,ipmi_list,ipmi_status,ipmi_reset,ipmi_cycle,ipmi_off,ipmi_on,reb
 
 VALID_WORKER_ID_REGEX=^.*(ms|yosemite)-.*
 
-DOWN_TIMEOUT=300
-UP_TIMEOUT=600
+DOWN_TIMEOUT=60
+UP_TIMEOUT=300

--- a/modules/toplevel/manifests/worker.pp
+++ b/modules/toplevel/manifests/worker.pp
@@ -10,8 +10,8 @@ class toplevel::worker inherits toplevel::base {
     include sudoers::reboot
     include users::builder
     include python::system_pip_conf
-    if ($::operatingsystem == 'Darwin') {
-        # roller user ssh only on macs for now
+    if ($::operatingsystem == 'Darwin') or ($::operatingsystem == 'Ubuntu') {
+        # roller user ssh
         include users::roller
     }
 

--- a/modules/users/manifests/roller/account.pp
+++ b/modules/users/manifests/roller/account.pp
@@ -16,6 +16,20 @@ class users::roller::account($username, $group, $grouplist, $home) {
     # create the user
 
     case $::operatingsystem {
+        CentOS, Ubuntu: {
+            if (secret('roller_pw_hash') == '') {
+                fail('No builder password hash set')
+            }
+
+            user {
+                $username:
+                    password   => secret('roller_pw_hash'),
+                    shell      => '/bin/bash',
+                    managehome => true,
+                    groups     => $grouplist,
+                    comment    => 'hardware controller';
+            }
+        }
         Darwin: {
             # use our custom type and provider, based on http://projects.puppetlabs.com/issues/12833
             # This should be replaced with 'user' once we are running a version of puppet containing the

--- a/modules/users/manifests/roller/setup.pp
+++ b/modules/users/manifests/roller/setup.pp
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 class users::roller::setup($home, $username, $group) {
     anchor {
         'users::roller::setup::begin': ;
@@ -17,8 +18,8 @@ class users::roller::setup($home, $username, $group) {
     } -> Anchor['users::roller::setup::end']
 
     case $::operatingsystem {
-        # Roller needs ssh for reboot on macs only
-        Darwin: {
+        # Roller first tries ssh to reboot
+        Ubuntu, Darwin: {
             include sudoers
             include sudoers::settings
             include users::roller

--- a/modules/users/templates/roller-allowed_commands.sh.erb
+++ b/modules/users/templates/roller-allowed_commands.sh.erb
@@ -5,7 +5,7 @@ if echo "$SSH_ORIGINAL_COMMAND" | grep -Eq '^/usr/sbin/bless --netboot --server 
     install=$(echo "$SSH_ORIGINAL_COMMAND" | grep -Eo 'bsdp://[\.0-9]+')
     logger -s "Hardware controller requested netboot from ${install}"
     sudo /usr/sbin/bless --netboot --server "${install}"
-    sudo reboot
+    sudo <%= scope.lookupvar('sudoers::settings::rebootpath') %>
 elif echo "$SSH_ORIGINAL_COMMAND" | grep -Eq '^reboot$'; then
     logger -s "Hardware controller requested reboot"
     sudo <%= scope.lookupvar('sudoers::settings::rebootpath') %>

--- a/modules/users/templates/roller-allowed_commands.sh.erb
+++ b/modules/users/templates/roller-allowed_commands.sh.erb
@@ -5,10 +5,10 @@ if echo "$SSH_ORIGINAL_COMMAND" | grep -Eq '^/usr/sbin/bless --netboot --server 
     install=$(echo "$SSH_ORIGINAL_COMMAND" | grep -Eo 'bsdp://[\.0-9]+')
     logger -s "Hardware controller requested netboot from ${install}"
     sudo /usr/sbin/bless --netboot --server "${install}"
-    sudo <%= scope.lookupvar('sudoers::settings::rebootpath') %>
+    nohup sudo <%= scope.lookupvar('sudoers::settings::rebootpath') %> &>/dev/null &
 elif echo "$SSH_ORIGINAL_COMMAND" | grep -Eq '^reboot$'; then
     logger -s "Hardware controller requested reboot"
-    sudo <%= scope.lookupvar('sudoers::settings::rebootpath') %>
+    nohup sudo <%= scope.lookupvar('sudoers::settings::rebootpath') %> &>/dev/null &
 else
     echo "Access denied"
     exit 1

--- a/modules/users/templates/roller-allowed_commands.sh.erb
+++ b/modules/users/templates/roller-allowed_commands.sh.erb
@@ -6,7 +6,7 @@ if echo "$SSH_ORIGINAL_COMMAND" | grep -Eq '^/usr/sbin/bless --netboot --server 
     logger -s "Hardware controller requested netboot from ${install}"
     sudo /usr/sbin/bless --netboot --server "${install}"
     sudo reboot
-elif echo "$SSH_ORIGINAL_COMMAND" | grep -Eq '^<%= scope.lookupvar('sudoers::settings::rebootpath') %>$'; then
+elif echo "$SSH_ORIGINAL_COMMAND" | grep -Eq '^reboot$'; then
     logger -s "Hardware controller requested reboot"
     sudo <%= scope.lookupvar('sudoers::settings::rebootpath') %>
 else


### PR DESCRIPTION
@dividehex @dragoscrisan 

1. fix network entries for fw module to add roller to iptables without trying to resolve the ips (I think the network firewall is only allowing ingress)
2. add "roller" user to Ubuntu workers with sudo for reboot
3. accept command "reboot" and not the full path
4. decrease the timeout for a reboot's is_down and is_up; If a reboot takes longer than a minute for the shutdown, then there is a problem and we can try a forced shutdown (like with ipmi/snmp).