### PR TITLE
pushapk_scriptworker: Bump pushapkscript and mozapkpublisher for Focus

### DIFF
--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -35,7 +35,7 @@ kiwisolver==1.0.1
 lxml==4.2.1
 matplotlib==2.2.2
 mohawk==0.3.4
-mozapkpublisher==0.7.2
+mozapkpublisher==0.8.0
 multidict==4.3.1
 networkx==2.1
 numpy==1.14.3
@@ -66,4 +66,4 @@ virtualenv==16.0.0
 voluptuous==0.11.1
 wcwidth==0.1.7
 yarl==1.2.4
-pushapkscript==0.7.0  # puppet: nodownload
+pushapkscript==0.8.0  # puppet: nodownload


### PR DESCRIPTION
This lets Firefox Focus use dedicated Google Play tracks