### PR TITLE
bug 1470496 - use a single gpg key across all prod scriptworkers

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -693,8 +693,8 @@ class config inherits config::base {
 
     # scriptworker
     $scriptworker_root                        = '/builds/scriptworker' # Used by scriptworker instances
-    $scriptworker_gpg_private_keys            = hiera_hash('scriptworker_gpg_private_keys')
-    $scriptworker_gpg_public_keys             = hiera_hash('scriptworker_gpg_public_keys')
+    $scriptworker_gpg_private_key             = secret('scriptworker_gpg_private_key')
+    $scriptworker_gpg_public_key              = secret('scriptworker_gpg_public_key')
 
     $l10n_bumper_env_config = {
         'mozilla-central' => {

--- a/modules/scriptworker/manifests/instance.pp
+++ b/modules/scriptworker/manifests/instance.pp
@@ -107,8 +107,8 @@ define scriptworker::instance(
         git_key_repo_url => $scriptworker::instance::settings::git_key_repo_url,
         git_pubkey_dir   => $git_pubkey_dir,
 
-        pubkey           => $config::scriptworker_gpg_public_keys[$fqdn],
-        privkey          => $config::scriptworker_gpg_private_keys[$fqdn],
+        pubkey           => $config::scriptworker_gpg_public_key,
+        privkey          => $config::scriptworker_gpg_private_key,
 
         username         => $username,
       }


### PR DESCRIPTION
Tested on signing-linux-dev1.