### PR TITLE
Change distinguished puppet master

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -86,7 +86,7 @@ class config inherits config::base {
     # only way to communicate to apt that the masters are all mirrors of one another.
     # See https://bugzilla.mozilla.org/show_bug.cgi?id=906785
     $apt_repo_server            = 'puppetagain-apt.pvt.build.mozilla.org'
-    $distinguished_puppetmaster = 'releng-puppet2.srv.releng.scl3.mozilla.com'
+    $distinguished_puppetmaster = 'releng-puppet2.srv.releng.mdc1.mozilla.com'
     $puppet_again_repo          = 'https://github.com/mozilla-releng/build-puppet'
     $puppetmaster_extsyncs      = {
         'slavealloc' => {

--- a/modules/fw/manifests/networks.pp
+++ b/modules/fw/manifests/networks.pp
@@ -100,8 +100,8 @@ class fw::networks {
                                         '10.51.48.21/32',  # releng-puppet1.srv.releng.mdc2.mozilla.com
                                         '10.51.48.22/32' ] # releng-puppet2.srv.releng.mdc2.mozilla.com
 
-    $distingushed_puppetmaster = [ '10.26.48.50/32',  # releng-puppet2.srv.releng.scl3.mozilla.com
-                                   '10.49.48.22/32' ] # releng-puppet2.srv.releng.mdc1.mozilla.com
+    $distingushed_puppetmaster = [  '10.26.48.50/32',  # releng-puppet2.srv.releng.scl3.mozilla.com
+                                    '10.49.48.22/32' ] # releng-puppet2.srv.releng.mdc1.mozilla.com
 
     $infra_bacula_scl3 = [ '10.22.75.200/32' ] # bacula1.private.scl3.mozilla.com
     $infra_bacula_mdc1 = [ '10.48.75.200/32' ] # bacula1.private.mdc1.mozilla.com

--- a/modules/fw/manifests/networks.pp
+++ b/modules/fw/manifests/networks.pp
@@ -92,6 +92,7 @@ class fw::networks {
                   '10.26.48.17/32' ] # slaveapi-dev1.srv.releng.scl3.mozilla.com
 
     $non_distingushed_puppetmasters = [ '10.26.48.45/32',  # releng-puppet1.srv.releng.scl3.mozilla.com
+                                        '10.26.48.50/32',  # releng-puppet2.srv.releng.scl3.mozilla.com
                                         '10.134.48.16/32', # releng-puppet1.srv.releng.use1.mozilla.com
                                         '10.132.48.16/32', # releng-puppet1.srv.releng.usw2.mozilla.com
                                         '10.49.48.21/32',  # releng-puppet1.srv.releng.mdc1.mozilla.com
@@ -99,7 +100,8 @@ class fw::networks {
                                         '10.51.48.21/32',  # releng-puppet1.srv.releng.mdc2.mozilla.com
                                         '10.51.48.22/32' ] # releng-puppet2.srv.releng.mdc2.mozilla.com
 
-    $distingushed_puppetmaster = [ '10.26.48.50/32' ] # releng-puppet2.srv.releng.scl3.mozilla.com
+    $distingushed_puppetmaster = [ '10.26.48.50/32',  # releng-puppet2.srv.releng.scl3.mozilla.com
+                                   '10.49.48.22/32' ] # releng-puppet2.srv.releng.mdc1.mozilla.com
 
     $infra_bacula_scl3 = [ '10.22.75.200/32' ] # bacula1.private.scl3.mozilla.com
     $infra_bacula_mdc1 = [ '10.48.75.200/32' ] # bacula1.private.mdc1.mozilla.com


### PR DESCRIPTION
This is a bit transitional since it will list both the new and old DM under the fw module.  Once the dust has settled, we can remove the old DM from the fw network DM list.