### PR TITLE
Downgrade prompt_toolkit to satisfy ipython reqs

### DIFF
--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -46,7 +46,7 @@ oauth2client==4.1.2
 parso==0.2.1
 pexpect==4.6.0
 pickleshare==0.7.4
-prompt_toolkit==2.0.3
+prompt_toolkit==1.0.15
 ptyprocess==0.5.2
 pyOpenSSL==18.0.0
 pyasn1==0.4.3


### PR DESCRIPTION
Follow up #80 which introduced https://tools.taskcluster.net/groups/T9NNzgxhSbmF1oNAhzwkFg/tasks/BQTUG7sIR2yvNbjkrksUjg/runs/0/logs/public%2Flogs%2Flive_backing.log#L27 

Tested against https://tools.taskcluster.net/groups/T9NNzgxhSbmF1oNAhzwkFg/tasks/BQTUG7sIR2yvNbjkrksUjg/runs/1 