### PR TITLE
Bug 1473281 - Add t linux64 ms 280 worker to staging pool

### DIFF
--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -1205,6 +1205,7 @@ node 't-linux64-ms-279.test.releng.mdc1.mozilla.com' {
 # This worker is part of staging pool
 node 't-linux64-ms-280.test.releng.mdc1.mozilla.com' {
     $aspects = [ 'low-security' ]
+    $slave_trustlevel = 'try'
     $taskcluster_worker_type  = 'gecko-t-linux-talos-beta'
     include fw::profiles::linux_taskcluster_worker
     include toplevel::worker::releng::taskcluster_worker::test::gpu

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -1206,7 +1206,7 @@ node 't-linux64-ms-279.test.releng.mdc1.mozilla.com' {
 node 't-linux64-ms-280.test.releng.mdc1.mozilla.com' {
     $aspects = [ 'low-security' ]
     $slave_trustlevel = 'try'
-    $taskcluster_worker_type  = 'gecko-t-linux-talos-beta'
+    $taskcluster_worker_type  = 'gecko-t-linux-talos-b'
     include fw::profiles::linux_taskcluster_worker
     include toplevel::worker::releng::taskcluster_worker::test::gpu
 }

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -1205,9 +1205,9 @@ node 't-linux64-ms-279.test.releng.mdc1.mozilla.com' {
 # Loaner for dcrisan; Bug 1410207
 node 't-linux64-ms-280.test.releng.mdc1.mozilla.com' {
     $aspects = [ 'low-security' ]
-    # $pin_puppet_server = 'releng-puppet2.srv.releng.scl3.mozilla.com'
-    # $pin_puppet_env    = 'dcrian'
-    include toplevel::server
+    $taskcluster_worker_type  = 'gecko-t-linux-talos-beta'
+    include fw::profiles::linux_taskcluster_worker
+    include toplevel::worker::releng::taskcluster_worker::test::gpu
 }
 
 # Loaner for dividehex; bug 1445842 and 1447766

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -1202,7 +1202,7 @@ node 't-linux64-ms-279.test.releng.mdc1.mozilla.com' {
     include toplevel::server
 }
 
-# Loaner for dcrisan; Bug 1410207
+# This worker is part of staging pool
 node 't-linux64-ms-280.test.releng.mdc1.mozilla.com' {
     $aspects = [ 'low-security' ]
     $taskcluster_worker_type  = 'gecko-t-linux-talos-beta'


### PR DESCRIPTION
Add t-linux64-ms-280.test.releng.mdc1.mozilla.com worker to staging pool.
Created a taskcluster staging pool called gecko-t-linux-talos-b