### PR TITLE
Make sure nrpe uses SSL by default on Ubuntu 16.04

### DIFF
--- a/modules/nrpe/manifests/base.pp
+++ b/modules/nrpe/manifests/base.pp
@@ -47,6 +47,15 @@ class nrpe::base {
                     require => Class['packages::nrpe'],
                     notify  => Class['nrpe::service'];
             }
+
+            # Make sure nrpe uses SSL by default on Ubuntu 16.04
+            if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '16.04' {
+                file { '/etc/default/nagios-nrpe-server':
+                    ensure  => present,
+                    content => "NRPE_OPTS=\"\"\n",
+                    require => Class['packages::nrpe'];
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This requires the nrpe Ubuntu package to be built with ssl enabled.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1449745