### PR TITLE
Bug 1458468 - Update nrpe package on roller servers

### DIFF
--- a/modules/packages/manifests/nrpe.pp
+++ b/modules/packages/manifests/nrpe.pp
@@ -26,10 +26,10 @@ class packages::nrpe {
                         Anchor['packages::nrpe::begin'] ->
                         package {
                             'nagios-nrpe-server':
-                                ensure          => '3.2.1-1-nossl',
+                                ensure          => '3.2.1-1',
                                 install_options => [ '--no-install-recommends' ];
                             'nagios-nrpe-plugin':
-                                ensure          => '3.2.1-1-nossl',
+                                ensure          => '3.2.1-1',
                                 install_options => [ '--no-install-recommends' ];
                         } -> Anchor['packages::nrpe::end']
                 }

--- a/modules/packages/manifests/nrpe.pp
+++ b/modules/packages/manifests/nrpe.pp
@@ -31,6 +31,9 @@ class packages::nrpe {
                             'nagios-nrpe-plugin':
                                 ensure          => '3.2.1-1',
                                 install_options => [ '--no-install-recommends' ];
+                            'nagios-plugins-extra':
+                                ensure          => '2.1.2-2ubuntu2',
+                                install_options => [ '--no-install-recommends' ];
                         } -> Anchor['packages::nrpe::end']
                 }
                 default: {

--- a/modules/packages/manifests/nrpe.pp
+++ b/modules/packages/manifests/nrpe.pp
@@ -26,10 +26,10 @@ class packages::nrpe {
                         Anchor['packages::nrpe::begin'] ->
                         package {
                             'nagios-nrpe-server':
-                                ensure          => '3.0.1-3',
+                                ensure          => '3.2.1-1-nossl',
                                 install_options => [ '--no-install-recommends' ];
                             'nagios-nrpe-plugin':
-                                ensure          => '3.0.1-3',
+                                ensure          => '3.2.1-1-nossl',
                                 install_options => [ '--no-install-recommends' ];
                         } -> Anchor['packages::nrpe::end']
                 }

--- a/modules/packages/manifests/setup.pp
+++ b/modules/packages/manifests/setup.pp
@@ -225,7 +225,7 @@ class packages::setup {
             }
             # to flush the package index, increase this value by one (or
             # anything, really, just change it).
-            $repoflag = 43
+            $repoflag = 44
             file {
                 '/etc/.repo-flag':
                     content =>


### PR DESCRIPTION
- Steps to  fix this error (this is a good occasion to create the package from nrpe 3.2.1-1 source):
  - compiled the source with --enable-ssl=no flag
  - named the package: nagios-nrpe-server_3.2.1-1_amd6_nossl.deb
  - tested the package on Ubuntu 16.04 docker container: 
         - intsaleld nagios_nrpe_server and nagios_nrpe_plugin packages:
         - running: /usr/lib/nagios/plugins/check_nrpe -H 127.0.0.1
NRPE v3.2.1