### PR TITLE
Restart nrpe service when ubuntu nrpe defaults changes

### DIFF
--- a/modules/nrpe/manifests/base.pp
+++ b/modules/nrpe/manifests/base.pp
@@ -53,6 +53,7 @@ class nrpe::base {
                 file { '/etc/default/nagios-nrpe-server':
                     ensure  => present,
                     content => "NRPE_OPTS=\"\"\n",
+                    notify  => Class['nrpe::service'],
                     require => Class['packages::nrpe'];
                 }
             }


### PR DESCRIPTION
When the default config file changes we should notify the nrpe service to restart and pick up the changes.