### PR TITLE
Upgrade signingserver & signingworker python packages.

### DIFF
--- a/modules/signingserver/files/linux_requirements.txt
+++ b/modules/signingserver/files/linux_requirements.txt
@@ -1,5 +1,5 @@
 # python_version: 27
-gevent==1.3.4
+gevent==1.3.5
 WebOb==1.8.2
 poster==0.8.1
 IPy==0.83

--- a/modules/signingserver/files/linux_requirements.txt
+++ b/modules/signingserver/files/linux_requirements.txt
@@ -1,5 +1,5 @@
 # python_version: 27
-gevent==1.3.3
+gevent==1.3.4
 WebOb==1.8.2
 poster==0.8.1
 IPy==0.83
@@ -10,7 +10,7 @@ flufl.lock==2.4.1  # pyup: <3.0
 pexpect==4.6.0
 # widevine: osx cant build cryptography and doesnt need these!
 ## install six and setuptools before cryptography
-setuptools==39.2.0
+setuptools==40.0.0
 six==1.11.0
 argparse==1.4.0
 enum34==1.1.6
@@ -23,4 +23,4 @@ altgraph==0.15
 idna==2.7
 pycparser==2.18
 wsgiref==0.1.2
-ptyprocess==0.5.2
+ptyprocess==0.6.0

--- a/modules/signingserver/files/mac_requirements.txt
+++ b/modules/signingserver/files/mac_requirements.txt
@@ -1,5 +1,5 @@
 # python_version: 27
-gevent==1.3.4
+gevent==1.3.5
 WebOb==1.8.2
 poster==0.8.1
 IPy==0.83

--- a/modules/signingserver/files/mac_requirements.txt
+++ b/modules/signingserver/files/mac_requirements.txt
@@ -1,5 +1,5 @@
 # python_version: 27
-gevent==1.3.3
+gevent==1.3.4
 WebOb==1.8.2
 poster==0.8.1
 IPy==0.83
@@ -8,4 +8,4 @@ redis==2.10.6
 # fluf.lock 3.0+ requires python 3
 flufl.lock==2.4.1  # pyup: <3.0
 pexpect==4.6.0
-ptyprocess==0.5.2
+ptyprocess==0.6.0

--- a/modules/signingworker/files/requirements.txt
+++ b/modules/signingworker/files/requirements.txt
@@ -12,7 +12,7 @@ configobj==5.0.6
 ecdsa==0.13
 functools32==3.2.3-2
 future==0.16.0
-idna==2.6
+idna==2.7
 jsonschema==2.6.0
 kombu==4.2.1
 mohawk==0.3.4
@@ -28,7 +28,7 @@ sh==1.12.14
 signingworker==0.15
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.1
+taskcluster==3.0.2
 total-ordering==0.1.0
 wsgiref==0.1.2
 vine==1.1.4


### PR DESCRIPTION
These look really safe. gevent is the most notable upgrade, and its changelog doesn't show anything remotely scary.