### PR TITLE
pin towncrier to 18.5.0 in py2 venv

### DIFF
--- a/modules/balrog_scriptworker/files/requirements-27.txt
+++ b/modules/balrog_scriptworker/files/requirements-27.txt
@@ -26,5 +26,5 @@ pycparser==2.18
 python-dateutil==2.7.3
 requests==2.19.1
 toml==0.9.4
-towncrier==18.6.0
+towncrier==18.5.0  # pyup: ignore
 urllib3==1.22


### PR DESCRIPTION
Due to https://github.com/mozilla-releng/balrogscript/issues/37
(towncrier drops py2 support in 18.6.0)