### PR TITLE
Bug 1476741: Only use pub pypi, not pvt

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -111,7 +111,7 @@ class config inherits config::base {
     # connection
     $puppetmaster_cert_extra_names = [$apt_repo_server]
 
-    $user_python_repositories      = [ 'https://pypi.pvt.build.mozilla.org/pub', 'https://pypi.pub.build.mozilla.org/pub' ]
+    $user_python_repositories      = [ 'https://pypi.pub.build.mozilla.org/pub', ]
 
     # Releng hosts are 'medium' by default.  Slaves are specifically overridden
     # with the 'low' level, and some others are flagged as 'high' or 'maximum'.


### PR DESCRIPTION
As part of migrating pypi to MDC1, we're only going to have a public pypi, no pvt any longer so remove references to it.