### PR TITLE
Stop disabling dotencode in Mercurial repos.

### DIFF
--- a/modules/mercurial/templates/hgrc.erb
+++ b/modules/mercurial/templates/hgrc.erb
@@ -13,9 +13,6 @@ git=True
 showfunc=True
 ignoreblanklines=True
 
-[format]
-dotencode=False
-
 [ui]
 username = Mozilla Release Engineering <release@mozilla.com>
 traceback = True

--- a/modules/mercurial/templates/mercurial.ini.erb
+++ b/modules/mercurial/templates/mercurial.ini.erb
@@ -74,9 +74,6 @@ share =
 ;win32mbcs =
 ;zeroconf =
 
-[format]
-dotencode=False
-
 [ui]
 username = Mozilla Release Engineering <release@mozilla.com>
 traceback = True


### PR DESCRIPTION
According to @indygreg, there's no reason we should be disabling dotencode. It's been supported by Mercurial for a very, very, very long time (since 1.7 according to https://www.mercurial-scm.org/wiki/RequiresFile#Known_requirements, which was released in 2010). Disabling it means that robustcheckout ends up clobbering stuff a lot for correctness, which slows down a lot of operations (particularly on the new merge day instance).

This patch affects everything with Mercurial installed, as far as I can tell, but based on what I've been told and read it should be perfectly safe.