### PR TITLE
Install Mercurial into signing server virtualenvs.

### DIFF
--- a/modules/signingserver/files/linux_requirements.txt
+++ b/modules/signingserver/files/linux_requirements.txt
@@ -24,3 +24,4 @@ idna==2.7
 pycparser==2.18
 wsgiref==0.1.2
 ptyprocess==0.6.0
+mercurial==4.6.2

--- a/modules/signingserver/files/mac_requirements.txt
+++ b/modules/signingserver/files/mac_requirements.txt
@@ -9,3 +9,4 @@ redis==2.10.6
 flufl.lock==2.4.1  # pyup: <3.0
 pexpect==4.6.0
 ptyprocess==0.6.0
+mercurial==4.6.2


### PR DESCRIPTION
@escapewindow discovered that the system Mercurial is broken on the Mac signing servers today. This is a quick fix to get a working Mercurial on them. May as well do it on Linux as well, it might make the necessary documentation changes simpler.