### PR TITLE
Don't set trusted-host in pip config's for pypi.pub.build.mozilla.org.

### DIFF
--- a/modules/config/manifests/base.pp
+++ b/modules/config/manifests/base.pp
@@ -176,7 +176,7 @@ class config::base {
     # a list of pypi mirrors that should be included in every user's pip.conf.  The
     # default points to Release Engineering's mirror, which is not a complete mirror
     # of pypi
-    $user_python_repositories = [ 'http://pypi.pub.build.mozilla.org/pub' ]
+    $user_python_repositories = [ 'https://pypi.pub.build.mozilla.org/pub' ]
 
     ##
     ## application-specific configs

--- a/modules/python/templates/user-pip-conf.erb
+++ b/modules/python/templates/user-pip-conf.erb
@@ -7,6 +7,3 @@ disable-pip-version-check = true
 find-links = <%- @user_python_repositories.each do |rep| %>
     <%= rep -%>
 <%- end %>
-trusted-host = <%- @user_python_repositories.each do |rep| %>
-    <%= URI.parse(rep).host -%>
-<%- end %>

--- a/modules/python27/templates/user-pip-conf.erb
+++ b/modules/python27/templates/user-pip-conf.erb
@@ -7,6 +7,3 @@ disable-pip-version-check = true
 find-links = <%- @user_python_repositories.each do |rep| %>
     <%= rep -%>
 <%- end %>
-trusted-host = <%- @user_python_repositories.each do |rep| %>
-    <%= URI.parse(rep).host -%>
-<%- end %>

--- a/modules/python3/templates/user-pip-conf.erb
+++ b/modules/python3/templates/user-pip-conf.erb
@@ -7,6 +7,3 @@ disable-pip-version-check = true
 find-links = <%- @user_python_repositories.each do |rep| %>
     <%= rep -%>
 <%- end %>
-trusted-host = <%- @user_python_repositories.each do |rep| %>
-    <%= URI.parse(rep).host -%>
-<%- end %>


### PR DESCRIPTION
We connect to it using https and it has a globally trusted certificate, so we
don't need to whitelist it.