### PR TITLE
bug 1477434: Bump signcode maxsize to 350MB.

### DIFF
--- a/modules/signingserver/manifests/instance.pp
+++ b/modules/signingserver/manifests/instance.pp
@@ -13,7 +13,7 @@ define signingserver::instance(
         $focus_jar_key_name = '', $focus_jar_digestalg = '', $focus_jar_sigalg = '',
         $signcode_timestamp = 'yes',
         $concurrency        = 4,
-        $signcode_maxsize   = 157286400) {
+        $signcode_maxsize   = 367001600) {
     include config
     include signingserver::base
     include users::signer


### PR DESCRIPTION
For ASan!