### PR TITLE
bug 1472860 - signingscript 7.0.1

### DIFF
--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -28,7 +28,7 @@ python-jose==3.0.0
 requests==2.19.1
 rsa==3.4.2
 scriptworker==14.0.0
-signingscript==7.0.0  # puppet: nodownload
+signingscript==7.0.1  # puppet: nodownload
 signtool==3.2.0
 simplejson==3.16.0
 six==1.11.0


### PR DESCRIPTION
This updates the host.cert for the new signing server ssl certs, per https://github.com/mozilla-releng/signingscript/pull/54 .