### PR TITLE
Doc secops interest in the signcode_maxsize value

### DIFF
--- a/modules/signingserver/manifests/instance.pp
+++ b/modules/signingserver/manifests/instance.pp
@@ -13,6 +13,8 @@ define signingserver::instance(
         $focus_jar_key_name = '', $focus_jar_digestalg = '', $focus_jar_sigalg = '',
         $signcode_timestamp = 'yes',
         $concurrency        = 4,
+        # When signcode_maxsize changes, please inform
+        # secops+fx-sig-verify@m.c as they have similar limit.
         $signcode_maxsize   = 367001600) {
     include config
     include signingserver::base


### PR DESCRIPTION
The fx-sig-verify tool also sets a maxsize. Keeping the two values in
sync avoids pages.

Related to #128 