### PR TITLE
pin taskcluster-client.py to <4.0.0 til we're ready

### DIFF
--- a/modules/addon_scriptworker/files/requirements.txt
+++ b/modules/addon_scriptworker/files/requirements.txt
@@ -29,7 +29,7 @@ rsa==3.4.2
 scriptworker==14.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/balrog_scriptworker/files/requirements-3.txt
+++ b/modules/balrog_scriptworker/files/requirements-3.txt
@@ -23,7 +23,7 @@ requests==2.19.1
 scriptworker==14.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -34,7 +34,7 @@ s3transfer==0.1.13
 scriptworker==14.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 toml==0.9.4
 towncrier==18.6.0
 urllib3==1.23

--- a/modules/bouncer_scriptworker/files/requirements.txt
+++ b/modules/bouncer_scriptworker/files/requirements.txt
@@ -24,7 +24,7 @@ requests==2.19.1
 scriptworker==14.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/buildbot_bridge/files/requirements.txt
+++ b/modules/buildbot_bridge/files/requirements.txt
@@ -1,7 +1,7 @@
 # python_version: 27
 requests==2.19.1
 arrow==0.12.1
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 sqlalchemy==1.2.10
 kombu==4.2.1
 redo==1.6

--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -62,7 +62,7 @@ rsa==3.4.2
 scriptworker==14.0.0
 simplegeneric==0.8.1
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 traitlets==4.3.2
 uritemplate==3.0.0
 urllib3==1.23

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -37,7 +37,7 @@ simplejson==3.16.0
 six==1.11.0
 slugid==1.0.7
 tabulate==0.8.2
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/releaserunner3/files/requirements.txt
+++ b/modules/releaserunner3/files/requirements.txt
@@ -11,7 +11,7 @@ requests==2.19.1
 simplejson==3.16.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 urllib3==1.22
 wsgiref==0.1.2
 zope.interface==4.5.0

--- a/modules/shipit_scriptworker/files/requirements.txt
+++ b/modules/shipit_scriptworker/files/requirements.txt
@@ -25,7 +25,7 @@ scriptworker==14.0.0
 shipitapi==1.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -33,7 +33,7 @@ signtool==3.2.0
 simplejson==3.16.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/signingworker/files/requirements.txt
+++ b/modules/signingworker/files/requirements.txt
@@ -28,7 +28,7 @@ sh==1.12.14
 signingworker==0.15
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 total-ordering==0.1.0
 wsgiref==0.1.2
 vine==1.1.4

--- a/modules/transparency_scriptworker/files/requirements.txt
+++ b/modules/transparency_scriptworker/files/requirements.txt
@@ -24,7 +24,7 @@ requests==2.19.1
 scriptworker==14.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/tree_scriptworker/files/requirements.txt
+++ b/modules/tree_scriptworker/files/requirements.txt
@@ -23,7 +23,7 @@ requests==2.19.1
 scriptworker==14.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2
+taskcluster==3.0.2  # pyup: <4.0.0
 treescript==1.1.0  # puppet: nodownload
 urllib3==1.23
 virtualenv==16.0.0


### PR DESCRIPTION
taskcluster-client.py 4.0.0 renames taskcluster.async to
taskcluster.aio, which is a breaking change. This commit pins our
version until we're ready.