### PR TITLE
Bug 1477554: drain puppet agents certs from releng-puppet1.srv.releng…

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -59,8 +59,8 @@ class config inherits config::base {
                           'releng-puppet2.srv.releng.mdc1.mozilla.com',
                           'releng-puppet1.srv.releng.mdc2.mozilla.com',
                           'releng-puppet2.srv.releng.mdc2.mozilla.com',
-                          'releng-puppet1.srv.releng.scl3.mozilla.com',
-#                          'releng-puppet2.srv.releng.scl3.mozilla.com',  # This intermediate CA is expiring on 2018/05/01, let's invalidate it until the cert is renewed
+#                          'releng-puppet1.srv.releng.scl3.mozilla.com', # Bug 1477554
+#                          'releng-puppet2.srv.releng.scl3.mozilla.com',
                           'releng-puppet1.srv.releng.use1.mozilla.com',
                           'releng-puppet1.srv.releng.usw2.mozilla.com',
                         ]


### PR DESCRIPTION
….scl3
This removes releng-puppet1.srv.releng.scl3 from the vaild_puppet_cas list.  Any hosts that currently have a cert issued from this intermediate CA will send a request to another CA to reissue their cert.  This will essentially drain this puppet master's CA of 'active' puppet agent certs over the next hour or so.