### PR TITLE
Install python3.6 to OSX workers

### DIFF
--- a/modules/toplevel/manifests/worker/releng.pp
+++ b/modules/toplevel/manifests/worker/releng.pp
@@ -9,7 +9,6 @@ class toplevel::worker::releng inherits toplevel::worker {
     # packages common to all workers
     include dirs::tools
     include packages::mozilla::python27
-    include packages::mozilla::python3
     include packages::mozilla::tooltool
     include packages::wget
     include packages::mozilla::py27_mercurial

--- a/modules/toplevel/manifests/worker/releng.pp
+++ b/modules/toplevel/manifests/worker/releng.pp
@@ -9,6 +9,7 @@ class toplevel::worker::releng inherits toplevel::worker {
     # packages common to all workers
     include dirs::tools
     include packages::mozilla::python27
+    include packages::mozilla::python3
     include packages::mozilla::tooltool
     include packages::wget
     include packages::mozilla::py27_mercurial

--- a/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
+++ b/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
@@ -6,6 +6,7 @@ class toplevel::worker::releng::generic_worker::test inherits toplevel::worker::
     include talos
     include vnc
     include ntp::daemon
+    include packages::mozilla::python3
     include dirs::builds::hg_shared
     include dirs::builds::git_shared
     include dirs::builds::tooltool_cache


### PR DESCRIPTION
Missed to include packages::mozilla::python3 package to workers definition