### PR TITLE
Update .pyup.yml to run every week on Wednesday

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -11,4 +11,4 @@ search: True
 
 # Because updates generally trigger service reloads/restarts, it's better to batch
 # these together when possible.
-schedule: every week
+schedule: every week on thursday

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -11,4 +11,4 @@ search: True
 
 # Because updates generally trigger service reloads/restarts, it's better to batch
 # these together when possible.
-schedule: every week on thursday
+schedule: every week on Wednesday


### PR DESCRIPTION
After a discussion with @mozbhearsum we have concluded that for the next few weeks we should be doing PyUp merge requests on Thursdays, as Mondays are usually busy with Releases and Merges.

This will stay like this for a few weeks, while CiDuty learns the INs and OUTs about this task, and when the team becomes autonomous this weekly actionable will change either on Saturday or Sunday, when there is a lot less stuff happening. 

@lundjordan If you are okay with the change/plan (review+), Ben will be merging this into the master branch.