### PR TITLE
Ignore slaveapi/files/requirements.txt from weekly upgrades.

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -12,3 +12,9 @@ search: True
 # Because updates generally trigger service reloads/restarts, it's better to batch
 # these together when possible.
 schedule: every week on Wednesday
+
+# Blacklist modules/slaveapi/files/requirements.txt
+# Upgrades to this module breaks the SlaveAPI dashboard. BUG 1467573
+requirements:
+  - modules/slaveapi/files/requirements.txt:
+      update: False


### PR DESCRIPTION
SlaveAPI dashboard was been broken for a while now, to be exact when this PR [#71]( https://github.com/mozilla-releng/build-puppet/pull/71/files#diff-95780eb30d106e421159cda544ff09ec) landed, our dashboard started to encounter problems. 

PR https://github.com/mozilla-releng/build-puppet/pull/143 is planning to fix that, but with the current deployment, PyUp will keep suggesting for upgrades.

This dashboard will be used up to the point of BuildBot EOL. This file could also serve as a nice training ground for CiDuty to do manual changes (upgrades/downgrades).

## Changes proposed:
Add the following lines, which will make PyUp ignore the SlaveAPI requirements text file:
```yml
requirements:
  - modules/slaveapi/files/requirements.txt:
      update: False
```
(based on docs found [here](https://pyup.io/docs/bot/config/#specify-files) )

@mozbhearsum do you see anything wrong with the PR?
Can we land this before PR 143?