### PR TITLE
disable mac mdc1 signing servers until we reimage

### DIFF
--- a/modules/signing_scriptworker/templates/dep-passwords.json.erb
+++ b/modules/signing_scriptworker/templates/dep-passwords.json.erb
@@ -11,9 +11,6 @@
         ["mac-v2-signing3.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
         ["mac-v2-signing4.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
         ["mac-v2-signing6.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
-        ["mac-v2-signing7.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
-        ["mac-v2-signing8.srv.releng.mdc1.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
-        ["mac-v2-signing9.srv.releng.mdc1.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
-        ["mac-v2-signing10.srv.releng.mdc1.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]]
+        ["mac-v2-signing7.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]]
     ]
 }

--- a/modules/signing_scriptworker/templates/passwords.json.erb
+++ b/modules/signing_scriptworker/templates/passwords.json.erb
@@ -11,10 +11,7 @@
         ["mac-v2-signing3.srv.releng.scl3.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"]],
         ["mac-v2-signing4.srv.releng.scl3.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"]],
         ["mac-v2-signing6.srv.releng.scl3.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"]],
-        ["mac-v2-signing7.srv.releng.scl3.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"]],
-        ["mac-v2-signing8.srv.releng.mdc1.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"]],
-        ["mac-v2-signing9.srv.releng.mdc1.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"]],
-        ["mac-v2-signing10.srv.releng.mdc1.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"]]
+        ["mac-v2-signing7.srv.releng.scl3.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"]]
     ],
     "<%= @env_config['scope_prefix'] %>cert:dep-signing": [
         ["signing4.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["gpg", "sha2signcode", "sha2signcodestub", "osslsigncode", "signcode", "mar", "mar_sha384", "mar_sha384", "jar", "emevoucher", "widevine", "widevine_blessed"]],
@@ -28,10 +25,7 @@
         ["mac-v2-signing3.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
         ["mac-v2-signing4.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
         ["mac-v2-signing6.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
-        ["mac-v2-signing7.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
-        ["mac-v2-signing8.srv.releng.mdc1.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
-        ["mac-v2-signing9.srv.releng.mdc1.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]],
-        ["mac-v2-signing10.srv.releng.mdc1.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]]
+        ["mac-v2-signing7.srv.releng.scl3.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"]]
     ],
     "<%= @env_config['scope_prefix'] %>cert:release-signing": [
         ["signing4.srv.releng.scl3.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["gpg", "sha2signcode", "sha2signcodestub", "osslsigncode", "signcode", "mar", "mar_sha384", "jar", "emevoucher", "widevine", "widevine_blessed"]],
@@ -45,9 +39,6 @@
         ["mac-v2-signing3.srv.releng.scl3.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"]],
         ["mac-v2-signing4.srv.releng.scl3.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"]],
         ["mac-v2-signing6.srv.releng.scl3.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"]],
-        ["mac-v2-signing7.srv.releng.scl3.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"]],
-        ["mac-v2-signing8.srv.releng.mdc1.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"]],
-        ["mac-v2-signing9.srv.releng.mdc1.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"]],
-        ["mac-v2-signing10.srv.releng.mdc1.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"]]
+        ["mac-v2-signing7.srv.releng.scl3.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"]]
     ]
 }


### PR DESCRIPTION
```
10:48 <dividehex> ok. I noticed the ds workflows for dep and signing in mdc1 were broken. So I don't think they were ever initialized properly
*snip*
10:49 <aki> this is mac? or mac+linux?
10:49 <dividehex> i don't know how much work that creates on your side and I don't want to bomb you with that
10:49 <dividehex> this is mac only
10:50 <dividehex> linux is fune
10:50 <aki> ah. well, mac is having issues, so maybe that'll help
10:50 <dividehex> fine
10:50 <aki> how long will that take?
10:50 <aki> i can disable just mac and then reenable when you're done
10:51 <dividehex> I think it takes about 30m to go from DS to fully puppetized
10:51 <aki> ok. let me prepare a disable patch
10:51 <bhearsum> can you hold off on 10 for a short while? i want to finish trying something on it
10:51 stephend|afk → stephend
10:51 <aki> sure, i'll send the disable patch r? to you so you can wait til you're ready :)
10:52 <bhearsum> oh, you can disable it still
10:52 <bhearsum> i just mean not to reimage yet
10:52 <dividehex> mac-v2-signing8.srv.releng.mdc1.mozilla.com is a different problem, dhouse rebooted it but it never came back up with access
10:52 <aki> ok
10:52 <aki> yeah, i noticed that. wasn't sure if it was just slow
10:52 <dividehex> it think mac-v2-signing8.srv.releng.mdc1 will need QTS hands in the datacenter
10:53 <dividehex> dhouse ^^
10:53 <dhouse> dividehex: ok. :( I'll file an issue with QTS
```