### PR TITLE
stop cloning tools automatically on mac signing servers due to bustage

### DIFF
--- a/modules/signingserver/manifests/instance.pp
+++ b/modules/signingserver/manifests/instance.pp
@@ -117,13 +117,17 @@ define signingserver::instance(
             packages        => $virtualenv_packages;
     }
 
-    mercurial::repo {
-        "signing-${title}-tools":
-            require => Python::Virtualenv[$basedir],
-            hg_repo => $tools_repo,
-            dst_dir => "${basedir}/tools",
-            user    => $user,
-            rev     => $code_tag;
+    # system hg is broken on mac signing servers =\
+    # a human should clone using the venv's bin/hg
+    if $::operatingsystem != 'Darwin' {
+        mercurial::repo {
+            "signing-${title}-tools":
+                require => Python::Virtualenv[$basedir],
+                hg_repo => $tools_repo,
+                dst_dir => "${basedir}/tools",
+                user    => $user,
+                rev     => $code_tag;
+        }
     }
 
     if $ssl_cert == '' {


### PR DESCRIPTION
The system mercurial is busted on mac signing servers, but we can use the signing server instance's bin/hg to clone. We have to ssh in to start the signing servers anyway, so this may be an acceptable stopgap solution.