### PR TITLE
Scriptworker15

### DIFF
--- a/modules/addon_scriptworker/files/requirements.txt
+++ b/modules/addon_scriptworker/files/requirements.txt
@@ -26,10 +26,10 @@ python-gnupg==0.4.3
 python-jose==3.0.0
 requests==2.19.1
 rsa==3.4.2
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/balrog_scriptworker/files/requirements-3.txt
+++ b/modules/balrog_scriptworker/files/requirements-3.txt
@@ -20,10 +20,10 @@ ptyprocess==0.6.0
 python-dateutil==2.7.3
 python-gnupg==0.4.3
 requests==2.19.1
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -31,10 +31,10 @@ python-gnupg==0.4.3
 redo==1.6
 requests==2.19.1
 s3transfer==0.1.13
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 toml==0.9.4
 towncrier==18.6.0
 urllib3==1.23

--- a/modules/bouncer_scriptworker/files/requirements.txt
+++ b/modules/bouncer_scriptworker/files/requirements.txt
@@ -21,10 +21,10 @@ ptyprocess==0.6.0
 python-dateutil==2.7.3
 python-gnupg==0.4.3
 requests==2.19.1
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -59,10 +59,10 @@ python-gnupg==0.4.3
 pytz==2018.5
 requests==2.19.1
 rsa==3.4.2
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 simplegeneric==0.8.1
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 traitlets==4.3.2
 uritemplate==3.0.0
 urllib3==1.23

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -32,12 +32,12 @@ pyxdg==0.26
 requests==2.19.1
 requests-toolbelt==0.8.0
 requests-unixsocket==0.1.5
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 simplejson==3.16.0
 six==1.11.0
 slugid==1.0.7
 tabulate==0.8.2
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/shipit_scriptworker/files/requirements.txt
+++ b/modules/shipit_scriptworker/files/requirements.txt
@@ -21,11 +21,11 @@ python-dateutil==2.7.3
 python-gnupg==0.4.3
 redo==1.6
 requests==2.19.1
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 shipitapi==1.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -27,13 +27,13 @@ python-gnupg==0.4.3
 python-jose==3.0.0
 requests==2.19.1
 rsa==3.4.2
-scriptworker==14.0.0  # pyup: <15.0.0
-signingscript==7.0.2  # puppet: nodownload
+scriptworker==15.0.0
+signingscript==7.0.4  # puppet: nodownload
 signtool==3.2.0
 simplejson==3.16.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/transparency_scriptworker/files/requirements.txt
+++ b/modules/transparency_scriptworker/files/requirements.txt
@@ -21,10 +21,10 @@ python-dateutil==2.7.3
 python-gnupg==0.4.3
 redo==1.6
 requests==2.19.1
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6

--- a/modules/tree_scriptworker/files/requirements.txt
+++ b/modules/tree_scriptworker/files/requirements.txt
@@ -20,10 +20,10 @@ ptyprocess==0.6.0
 python-dateutil==2.7.3
 python-gnupg==0.4.3
 requests==2.19.1
-scriptworker==14.0.0  # pyup: <15.0.0
+scriptworker==15.0.0
 six==1.11.0
 slugid==1.0.7
-taskcluster==3.0.2  # pyup: <4.0.0
+taskcluster==4.0.1
 treescript==1.1.1  # puppet: nodownload
 urllib3==1.23
 virtualenv==16.0.0


### PR DESCRIPTION
Re-enable scriptworker 15 and with taskcluster 4.0.1, which should fix the double-slash issue.

I plan on running this in my puppet env for a bit before rolling out to the rest of the pool.