### PR TITLE
Disable pip version check to avoid cron spam eating up inboxes.

### DIFF
--- a/modules/puppetmaster/templates/puppetmaster-pip-download.sh.erb
+++ b/modules/puppetmaster/templates/puppetmaster-pip-download.sh.erb
@@ -61,7 +61,7 @@ if [ -f ${logfile} ]; then
             # --no-deps beacuse we don't want to download implicit dependencies (we'd rather have errors, and make them explicit)
             # --python-version to make sure we're getting the correct wheels
             # -d to make sure the packages go to the right place
-            ${pip_binary} download -q --cache-dir=/root/.cache/pip-${python_version} --no-deps --python-version ${python_version} -d $download_dir $dep >> $logfile 2>&1
+            ${pip_binary} --disable-pip-version-check download -q --cache-dir=/root/.cache/pip-${python_version} --no-deps --python-version ${python_version} -d $download_dir $dep >> $logfile 2>&1
         done
     fi
 


### PR DESCRIPTION
We're getting a bunch of e-mail (every 5 min x 2) about:

> You are using pip version 10.0.1, however version 18.0 is available.
> You should consider upgrading via the 'pip install --upgrade pip' command.

This should stop the bleeding.

For reference we don't manage pip version for the download venv: https://dxr.mozilla.org/build-central/rev/9cb089f5a074bc4d138252914f3d07c8ad6e6229/puppet/modules/puppetmaster/manifests/data.pp#109