### PR TITLE
Bug 1480412 - fix tc_environment var name

### DIFF
--- a/modules/generic_worker/manifests/init.pp
+++ b/modules/generic_worker/manifests/init.pp
@@ -17,7 +17,7 @@ class generic_worker {
             $livelog_secret = hiera('livelog_secret')
             $worker_group = regsubst($::fqdn, '.*\.releng\.(.+)\.mozilla\..*', '\1')
 
-            if ($environment == 'staging') {
+            if ($tc_environment == 'staging') {
                 $worker_type = "gecko-t-osx-${macos_version}-beta"
             }
             else {


### PR DESCRIPTION
I ended up making the staging workers take production tasks because the "tc_environment" was set to staging, but the in-master module was looking for the variable named "environment".

So this applies the tc_environment to the workerType name set up.