### PR TITLE
Bug 1482162: block vnc on mac-v2-signing and macdepsigning

### DIFF
--- a/modules/fw/manifests/profiles/mac_depsigning.pp
+++ b/modules/fw/manifests/profiles/mac_depsigning.pp
@@ -6,7 +6,6 @@ class fw::profiles::mac_depsigning {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
-            include ::fw::roles::vnc_from_rejh_logging
             include ::fw::roles::ssh_from_rejh_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::dep_signing_from_osx

--- a/modules/fw/manifests/profiles/mac_signing.pp
+++ b/modules/fw/manifests/profiles/mac_signing.pp
@@ -5,8 +5,7 @@
 class fw::profiles::mac_signing {
 
     case $::fqdn {
-        /.*\.(scl3|mdc1)\.mozilla\.com/: {
-            include ::fw::roles::vnc_from_rejh_logging
+        /.*\.(scl3|mdc1|mdc2)\.mozilla\.com/: {
             include ::fw::roles::ssh_from_rejh_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::dep_signing_from_osx


### PR DESCRIPTION
This removes the host-based pf firewall rule allowing incoming vnc connections to mac-v2-signing and depsigning.  Also adds mdc2 to macsigning profile since it was missing. 👎