### PR TITLE
Don't generate trailing whitespace in `l10n-changesets.json`.

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -698,12 +698,12 @@ class config inherits config::base {
     $l10n_bumper_env_config = {
         'mozilla-central' => {
             mozharness_repo     => 'https://hg.mozilla.org/mozilla-central',
-            mozharness_revision => 'b159a6ed52f7',
+            mozharness_revision => '9d21ea9afe7a61cfe80d577809bf3191e816baec',
             config_file         => 'l10n_bumper/mozilla-central.py',
         },
         'mozilla-beta'    => {
             mozharness_repo     => 'https://hg.mozilla.org/mozilla-central',
-            mozharness_revision => '9c2f023a62d0',
+            mozharness_revision => '9d21ea9afe7a61cfe80d577809bf3191e816baec',
             config_file         => 'l10n_bumper/mozilla-beta.py',
         },
     }


### PR DESCRIPTION
Once https://hg.mozilla.org/integration/autoland/rev/9d21ea9afe7a merges to m-c, we should update the bumpers to use the changes.