### PR TITLE
Bug 1479619 - add bouncer_check on bm01

### DIFF
--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -436,6 +436,7 @@ node 'buildbot-master01.bb.releng.use1.mozilla.com' {
     include toplevel::server::buildmaster::mozilla
     include toplevel::mixin::l10n_bumper
     include toplevel::mixin::releaserunner3
+    include toplevel::mixin::bouncer_check
 }
 
 node 'buildbot-master02.bb.releng.use1.mozilla.com' {


### PR DESCRIPTION
The plan here is to move bouncer_check from bm81 (scl3) to bm01 (use1). Since there are related nagios checks lets add to bm01 first, move the nagios checks separately, and then bm81 will get cleaned up with the rest of scl3.