### PR TITLE
Revert "scriptworker 16.0.0"

### DIFF
--- a/modules/addon_scriptworker/files/requirements.txt
+++ b/modules/addon_scriptworker/files/requirements.txt
@@ -26,7 +26,7 @@ python-gnupg==0.4.3
 python-jose==3.0.1
 requests==2.19.1
 rsa==3.4.2
-scriptworker==16.0.0
+scriptworker==15.0.4
 six==1.11.0
 slugid==1.0.7
 taskcluster==4.0.1

--- a/modules/balrog_scriptworker/files/requirements-3.txt
+++ b/modules/balrog_scriptworker/files/requirements-3.txt
@@ -20,7 +20,7 @@ ptyprocess==0.6.0
 python-dateutil==2.7.3
 python-gnupg==0.4.3
 requests==2.19.1
-scriptworker==16.0.0
+scriptworker==15.0.4
 six==1.11.0
 slugid==1.0.7
 taskcluster==4.0.1

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -32,7 +32,7 @@ python-gnupg==0.4.3
 redo==1.7
 requests==2.19.1
 s3transfer==0.1.13
-scriptworker==16.0.0
+scriptworker==15.0.4
 six==1.11.0
 slugid==1.0.7
 taskcluster==4.0.1

--- a/modules/bouncer_scriptworker/files/requirements.txt
+++ b/modules/bouncer_scriptworker/files/requirements.txt
@@ -22,7 +22,7 @@ ptyprocess==0.6.0
 python-dateutil==2.7.3
 python-gnupg==0.4.3
 requests==2.19.1
-scriptworker==16.0.0
+scriptworker==15.0.4
 six==1.11.0
 slugid==1.0.7
 taskcluster==4.0.1

--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -59,7 +59,7 @@ python-gnupg==0.4.3
 pytz==2018.5
 requests==2.19.1
 rsa==3.4.2
-scriptworker==16.0.0
+scriptworker==15.0.4
 simplegeneric==0.8.1
 slugid==1.0.7
 taskcluster==4.0.1

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -32,7 +32,7 @@ pyxdg==0.26
 requests==2.19.1
 requests-toolbelt==0.8.0
 requests-unixsocket==0.1.5
-scriptworker==16.0.0
+scriptworker==15.0.4
 simplejson==3.16.0
 six==1.11.0
 slugid==1.0.7

--- a/modules/shipit_scriptworker/files/requirements.txt
+++ b/modules/shipit_scriptworker/files/requirements.txt
@@ -21,7 +21,7 @@ python-dateutil==2.7.3
 python-gnupg==0.4.3
 redo==1.7
 requests==2.19.1
-scriptworker==16.0.0
+scriptworker==15.0.4
 shipitapi==1.0.0
 six==1.11.0
 slugid==1.0.7

--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -28,7 +28,7 @@ python-jose==3.0.1
 requests_hawk==1.0.0
 requests==2.19.1
 rsa==3.4.2
-scriptworker==16.0.0
+scriptworker==15.0.4
 signingscript==8.0.1  # puppet: nodownload
 signtool==3.2.1
 simplejson==3.16.0

--- a/modules/transparency_scriptworker/files/requirements.txt
+++ b/modules/transparency_scriptworker/files/requirements.txt
@@ -21,7 +21,7 @@ python-dateutil==2.7.3
 python-gnupg==0.4.3
 redo==1.7
 requests==2.19.1
-scriptworker==16.0.0
+scriptworker==15.0.4
 six==1.11.0
 slugid==1.0.7
 taskcluster==4.0.1

--- a/modules/tree_scriptworker/files/requirements.txt
+++ b/modules/tree_scriptworker/files/requirements.txt
@@ -20,7 +20,7 @@ ptyprocess==0.6.0
 python-dateutil==2.7.3
 python-gnupg==0.4.3
 requests==2.19.1
-scriptworker==16.0.0
+scriptworker==15.0.4
 six==1.11.0
 slugid==1.0.7
 taskcluster==4.0.1


### PR DESCRIPTION
Reverts mozilla-releng/build-puppet#208

From IRC:
> tomprince: Scriptworker 16.0 is going to cause release tasks to retry endlessly (it doesn't handle that relpro actions aren't hooks) so we should probably back it out before starting any releases.
> ...
> tomprince: Just need to revert the build-puppet commit that upgraded things.
> rail: revert https://github.com/mozilla-releng/build-puppet/pull/208?
> tomprince: Yeah.