### PR TITLE
Revert "Bug 1489603: let systemd restart mig after an upgrade"

### DIFF
--- a/modules/mig/manifests/agent/daemon.pp
+++ b/modules/mig/manifests/agent/daemon.pp
@@ -19,13 +19,10 @@ class mig::agent::daemon {
             case $::operatingsystemrelease {
                 16.04: {
                     exec {
-                        # mig hangs sometimes after a package upgrade
-                        # so let systemd handle restarting it after an upgrade
-                        'systemd restart mig':
-                            command     => '/bin/systemctl restart mig-agent.service',
-                            subscribe   => Class['packages::mozilla::mig_agent'],
-                            refreshonly => true,
-
+                        'kill mig':
+                            command   => "/bin/kill -s 2 $(${mig_path} -q=pid); ${mig_path}",
+                            subscribe => Class['packages::mozilla::mig_agent'],
+                            notify    => Service['mig-agent']
                     }
                     service {
                         'mig-agent':


### PR DESCRIPTION
This reverts commit b2e01fb8c3362f062d89315b94118c9175825f81. (Bug 1489603)

New installs on Ubuntu get stuck because puppet tries to restart mig-agent before mig-agent service is set up and fails.