### PR TITLE
Bug 1488396 - Update pushsnap_scriptworker to latest snapcraft

### DIFF
--- a/modules/packages/manifests/libsodium.pp
+++ b/modules/packages/manifests/libsodium.pp
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::libsodium {
+    case $::operatingsystem {
+        CentOS: {
+            realize(Packages::Yumrepo['libsodium'])
+            package {
+                ['libsodium', 'libsodium-devel']:
+                    ensure => latest;
+            }
+        }
+
+        default: {
+            fail("Cannot install on ${::operatingsystem}")
+        }
+    }
+}

--- a/modules/packages/manifests/setup.pp
+++ b/modules/packages/manifests/setup.pp
@@ -189,11 +189,15 @@ class packages::setup {
 
                 'libsodium':
                     url_path => "repos/yum/custom/libsodium/${::architecture}";
+
+                'xdelta':
+                    url_path => "repos/yum/custom/mozilla-xdelta/${::architecture}";
+
             }
 
             # to flush the metadata cache, increase this value by one (or
             # anything, really, just change it).
-            $repoflag = 96
+            $repoflag = 97
             file {
                 '/etc/.repo-flag':
                     content =>

--- a/modules/packages/manifests/setup.pp
+++ b/modules/packages/manifests/setup.pp
@@ -186,11 +186,14 @@ class packages::setup {
 
                 'dhcp':
                     url_path => "repos/yum/custom/dhcp/${::architecture}";
+
+                'libsodium':
+                    url_path => "repos/yum/custom/libsodium/${::architecture}";
             }
 
             # to flush the metadata cache, increase this value by one (or
             # anything, really, just change it).
-            $repoflag = 95
+            $repoflag = 96
             file {
                 '/etc/.repo-flag':
                     content =>

--- a/modules/packages/manifests/xdelta3.pp
+++ b/modules/packages/manifests/xdelta3.pp
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::xdelta3 {
+    case $::operatingsystem {
+        CentOS: {
+            realize(Packages::Yumrepo['xdelta'])
+            package {
+                ['xdelta3']:
+                    ensure => latest;
+            }
+        }
+
+        default: {
+            fail("Cannot install on ${::operatingsystem}")
+        }
+    }
+}

--- a/modules/packages/manifests/xdelta3.spec
+++ b/modules/packages/manifests/xdelta3.spec
@@ -1,0 +1,84 @@
+# [2018-09-21] NOTE from jlorenzo: The original file comes from https://github.com/jmacd/xdelta/issues/224#issuecomment-355830395
+#
+# I couldn't get the devtoolset repo to work, so I ended up manually downloading all deps
+# from http://mirror.centos.org/centos/6.10/sclo/x86_64/rh/devtoolset-3/.
+#
+# Moreover, for an unknown reason, `rpmbuild -ba xdelta.spec` was always failing because
+# *all* deps were not installed (even though they really were). I had to comment out all
+# BuildRequires entries.
+#
+# There was a tiny bug in this file, too. I swapped `make DESTDIR=%RPM_BUILD_ROOT install` to `make DESTDIR=$RPM_BUILD_ROOT install`.
+#
+# Finally, I built the package within the docker image "centos:centos6" (which is
+# "CentOS release 6.10 (Final)"). This image couldn't start on my regular Linux host
+# (there was some crash due to systemd). I worked around it by running docker within a
+# Ubuntu 16.04 VM. 
+
+# ORIGINAL NOTE: This spec file was written on on CentOS 6 for EL6-based distros.
+# If building on an EL6-based distro, you need EPEL and CERN's devtoolset:
+# https://fedoraproject.org/wiki/EPEL
+# http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo
+# http://linuxsoft.cern.ch/cern/scl/RPM-GPG-KEY-cern
+#
+# On other distros, comment out the BuildRequires from those distros then
+# uncomment their corresponding "generic" BuildRequires. Also remember to
+# comment/uncomment the appropriate lines in %%build .
+
+Name:		xdelta3
+Summary:	Compare binary files and produce deltas
+License:	APLv2
+URL:		https://github.com/jmacd/xdelta
+Group:		System/Utilities
+Version:	3.1.0
+Release:	1%{dist}
+
+BuildRequires:	libtool
+BuildRequires:	xz
+BuildRequires:	xz-lzma-compat
+BuildRequires:	xz-devel
+#BuildRequires:	gcc >= 4.8.0
+#BuildRequires:	gcc-c++ >= 4.8.0
+BuildRequires:	automake
+BuildRequires:	autoconf >= 2.68
+
+# From EPEL:
+BuildRequires:	autoconf268
+# From CERN:
+BuildRequires:	devtoolset-3-gcc
+BuildRequires:	devtoolset-3-gcc-c++
+BuildRequires:	devtoolset-3-toolchain
+
+Source0:	https://github.com/jmacd/xdelta/archive/v%{version}.tar.gz
+
+%description
+%{name} can be used to compare binary files and produce compressed deltas
+containing the changes.
+
+%prep
+%setup -q -n xdelta-%{version}/%{name}
+
+%build
+#autoreconf -fvi
+autoreconf268 -fvi
+%configure \
+	--enable-debug-symbols \
+	--with-liblzma
+make
+
+%install
+rm -rf $RPM_BUILD_ROOT
+
+make DESTDIR=$RPM_BUILD_ROOT install
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-, root, root, -)
+%doc README.md COPYING
+%{_bindir}/*
+%{_mandir}/*/*
+
+%changelog
+* Sat Jan 06 2018 Anonymous Coward - 3.1.0-1
+- Initial RPM

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -16,7 +16,7 @@ idna==2.7
 idna_ssl==1.1.0
 json-e==2.7.0
 jsonschema==2.6.0
-# Puppet check is deactivated because it requires some distro library to be installed.
+# Puppet check is deactivated because it requires some distro library (libsodium) to be installed.
 libnacl==1.3.6    # puppet: nodownload
 mohawk==0.3.4
 multidict==4.4.2
@@ -24,7 +24,8 @@ pexpect==4.6.0
 progressbar33==2.4
 ptyprocess==0.6.0
 pyelftools==0.24
-pymacaroons==0.9.2
+# Puppet check is deactivated because it requires some distro library (libsodium) to be installed.
+pymacaroons==0.9.2    # puppet: nodownload
 python-dateutil==2.7.3
 python-debian==0.1.28
 python-gnupg==0.4.3

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -1,12 +1,9 @@
 # python_version: 36
-PyNaCl==1.2.1
 PyYAML==3.13
 aiohttp==3.4.4
 arrow==0.12.1
 async_timeout==3.0.0
 attrs==18.2.0
-certifi==2018.8.24
-cffi==1.11.5
 chardet==3.0.4
 click==6.7
 defusedxml==0.5.0
@@ -16,29 +13,28 @@ idna==2.7
 idna_ssl==1.1.0
 json-e==2.7.0
 jsonschema==2.6.0
+libnacl==1.3.6
 mohawk==0.3.4
 multidict==4.4.2
 pexpect==4.6.0
 progressbar33==2.4
 ptyprocess==0.6.0
-pycparser==2.19
-pyelftools==0.25
-pymacaroons==0.13.0
-pysha3==1.0.2
+pyelftools==0.24
+pymacaroons==0.9.2
 python-dateutil==2.7.3
-python-debian==0.1.33
+python-debian==0.1.28
 python-gnupg==0.4.3
-pyxdg==0.26
-requests==2.19.1
-requests-toolbelt==0.8.0
+pyxdg==0.25
+requests==2.9.1
+requests-toolbelt==0.6.0
 requests-unixsocket==0.1.5
 scriptworker==16.0.1
-simplejson==3.16.0
+simplejson==3.8.2
 six==1.11.0
 slugid==1.0.7
-tabulate==0.8.2
+tabulate==0.7.5
 taskcluster==4.0.1
 urllib3==1.23
 virtualenv==16.0.0
 yarl==1.2.6
-pushsnapscript==0.2.1  # puppet: nodownload
+pushsnapscript==0.2.2  # puppet: nodownload

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -1,4 +1,7 @@
+# pyup: ignore file
 # python_version: 36
+# Please do not update this file without end-to-end testing. pushsnapscript has a major hack in its
+# dependencies. Please read https://bugzilla.mozilla.org/show_bug.cgi?id=1447263#c15 for context.
 PyYAML==3.13
 aiohttp==3.4.4
 arrow==0.12.1

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -13,7 +13,8 @@ idna==2.7
 idna_ssl==1.1.0
 json-e==2.7.0
 jsonschema==2.6.0
-libnacl==1.3.6
+# Puppet check is deactivated because it requires some distro library to be installed.
+libnacl==1.3.6    # puppet: nodownload
 mohawk==0.3.4
 multidict==4.4.2
 pexpect==4.6.0

--- a/modules/pushsnap_scriptworker/manifests/init.pp
+++ b/modules/pushsnap_scriptworker/manifests/init.pp
@@ -12,6 +12,7 @@ class pushsnap_scriptworker {
     include packages::make
     include packages::libffi
     include packages::libsodium
+    include packages::xdelta3
     include packages::mozilla::squashfs_tools
     include tweaks::scriptworkerlogrotate
 

--- a/modules/pushsnap_scriptworker/manifests/init.pp
+++ b/modules/pushsnap_scriptworker/manifests/init.pp
@@ -11,8 +11,8 @@ class pushsnap_scriptworker {
     include packages::gcc
     include packages::make
     include packages::libffi
+    include packages::libsodium
     include packages::mozilla::squashfs_tools
-    include tweaks::scriptworkerlogrotate
     include tweaks::scriptworkerlogrotate
 
     # If the Python installation changes, we need to rebuild the virtualenv


### PR DESCRIPTION
I rebuilt the dependency list with https://github.com/mozilla-releng/pushsnapscript/pull/13. Maybe bumping some of the deps caused [bug 1488396](https://bugzil.la/1488396). I'm looking into it.