### PR TITLE
10.10 concurrency 2

### DIFF
--- a/modules/toplevel/manifests/server/signing.pp
+++ b/modules/toplevel/manifests/server/signing.pp
@@ -32,6 +32,7 @@ class toplevel::server::signing inherits toplevel::server {
             }
             $concurrency = $::macosx_productversion_major ? {
                 10.9    => 2,
+                10.10   => 2,
                 default => 4
             }
 


### PR DESCRIPTION
Tested on mac-v2-signing13. This should hopefully reduce the churn on the mac signing servers, speeding things up. We can look at our numbers post-concurrency-tweak and compare.

Not sure if we need to restart the servers after this.