### PR TITLE
Lzma python

### DIFF
--- a/modules/packages/manifests/mozilla/python3.pp
+++ b/modules/packages/manifests/mozilla/python3.pp
@@ -25,7 +25,7 @@ class packages::mozilla::python3 {
             Anchor['packages::mozilla::python3::begin'] ->
             package {
                 'mozilla-python36':
-                    ensure => '3.6.5-1.el6';
+                    ensure => '3.6.5-2.el6';
             } -> Anchor['packages::mozilla::python3::end']
         }
         Darwin: {

--- a/modules/packages/manifests/mozilla/python3.spec
+++ b/modules/packages/manifests/mozilla/python3.spec
@@ -7,7 +7,7 @@
 
 Name:       mozilla-%{realname}
 Version:        %{pyver}.%{pyrel}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        This is a packaging of %{realname} %{version}-%{release} for Mozilla Release Engineering infrastructure
 
 Group:          mozilla
@@ -27,6 +27,7 @@ BuildRequires: tix-devel bzip2-devel sqlite-devel
 BuildRequires: autoconf
 BuildRequires: db4-devel
 BuildRequires: libffi-devel
+BuildRequires: xz-devel
 
 %description
 %{realname} %{version}-%{release} for Mozilla Release Engineering infrastructure
@@ -71,5 +72,7 @@ rm -rf $RPM_BUILD_ROOT
 %doc /usr/share/man/man1/python3.6.1.gz
 
 %changelog
+* Mon Sep 24 2018 Aki Sasaki <aki mozilla com> 3.6.5-2
+- add lzma support
 * Fri Apr 13 2018 Ben Hearsum <bhearsum mozilla com> 3.6.5-1
 - initial commit, copied from py35

--- a/modules/packages/manifests/setup.pp
+++ b/modules/packages/manifests/setup.pp
@@ -198,7 +198,7 @@ class packages::setup {
             # to flush the metadata cache, increase this value by one (or
             # anything, really, just change it).
 
-            $repoflag = 98
+            $repoflag = 99
 
             file {
                 '/etc/.repo-flag':


### PR DESCRIPTION
This patch allows for a python 3.6.5-2 with lzma support. (That, in turn, unblocks the use of mardor in signingscript.)

I've tested this: signingscript-with-hash-signing works when testing https://github.com/mozilla-releng/signingscript/pull/69 using this custom build of python. I also tested against the current signingscript, after I uninstalled `xz-devel`; that appears to still work, though I haven't tested on a pristine environment (installing and uninstalling xz-devel may leave some cruft?). The main downside of this patch is that the scriptworkers delete their virtualenvs when this lands, leading to lengthy downtimes. We'll want to land when the tree is fairly quiet.