### PR TITLE
Bug 1490875: fw allow syslog from qa.mtv2 to mdc1/2

### DIFF
--- a/modules/fw/manifests/networks.pp
+++ b/modules/fw/manifests/networks.pp
@@ -177,4 +177,6 @@ class fw::networks {
     $infra_corp_jumphost = [  '10.48.72.100/32',  # ssh1.corpdmz.mdc1.mozilla.com
                               '10.50.72.100/32' ] # ssh1.corpdmz.mdc2.mozilla.com
 
+    # mtv2 qa network
+    $mtv2_qa = [ '10.252.73.0/24' ] # *.qa.mtv2.mozilla.com
 }

--- a/modules/fw/manifests/profiles/log_aggregator.pp
+++ b/modules/fw/manifests/profiles/log_aggregator.pp
@@ -9,11 +9,13 @@ class fw::profiles::log_aggregator {
             include ::fw::roles::ssh_from_rejh_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::syslog_from_mdc1_releng
+            include ::fw::roles::syslog_from_mtv2_qa
         }
         /.*\.mdc2\.mozilla\.com/: {
             include ::fw::roles::ssh_from_rejh_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::syslog_from_mdc2_releng
+            include ::fw::roles::syslog_from_mtv2_qa
         }
         default:{
             # Silently skip other DCs

--- a/modules/fw/manifests/roles/syslog_from_mtv2_qa.pp
+++ b/modules/fw/manifests/roles/syslog_from_mtv2_qa.pp
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::syslog_from_mtv2_qa {
+    include fw::networks
+
+    fw::rules { 'allow_syslog_udp_from_mtv2_qa':
+        sources =>  $::fw::networks::mtv2_qa,
+        app     => 'syslog_udp'
+    }
+    fw::rules { 'allow_syslog_tcp_from_mtv2_qa':
+        sources =>  $::fw::networks::mtv2_qa,
+        app     => 'syslog_tcp'
+    }
+}


### PR DESCRIPTION
        This commit modifies the fw module to allow syslog traffic from
        the qa network in mtv2 to reach the mdc1 and mdc2 releng log
        aggregators which in turn forward to papertail at this time.
        This is in addtion to the network acls managed by netops.