### PR TITLE
mobile: use autograph-external domain

### DIFF
--- a/modules/signing_scriptworker/templates/passwords-mobile.json.erb
+++ b/modules/signing_scriptworker/templates/passwords-mobile.json.erb
@@ -8,6 +8,6 @@
         ["signing12.srv.releng.mdc2.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["focus-jar"], "signing_server"]
     ],
     "project:mobile:fenix:releng:signing:cert:release-signing": [
-        ["https://autograph.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_fenix_prod_username"]) %>", "<%= scope.function_secret(["autograph_fenix_prod_password"]) %>", ["autograph_fenix"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_fenix_prod_username"]) %>", "<%= scope.function_secret(["autograph_fenix_prod_password"]) %>", ["autograph_fenix"], "autograph"]
     ]
 }


### PR DESCRIPTION
this is a no-op as right now, autograph-external points to autograph. we will be switching the autograph DNS over to an internal only LB in the future, hence this change.