### PR TITLE
Autograph hash

### DIFF
--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -2,34 +2,42 @@
 PyYAML==3.13
 aiohttp==3.4.4
 arrow==0.12.1
+asn1crypto==0.24.0
 async_timeout==3.0.0
 attrs==18.2.0
+backports.lzma==0.0.13
 certifi==2018.8.24
+cffi==1.11.5
 chardet==3.0.4
-datadog==0.22.0
+click==7.0
+construct==2.9.45
+cryptography==2.3.1
+datadog==0.17.0  # pyup: ignore
 decorator==4.3.0
 defusedxml==0.5.0
 dictdiffer==0.7.1
 ecdsa==0.13
 frozendict==1.2
 future==0.16.0
-idna_ssl==1.1.0
 idna==2.7
+idna_ssl==1.1.0
 json-e==2.7.1
 jsonschema==2.6.0
+mar==3.0.0
 mohawk==0.3.4
 multidict==4.4.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pyasn1==0.4.4
+pycparser==2.19
 python-dateutil==2.7.3
 python-gnupg==0.4.3
 python-jose==3.0.1
-requests_hawk==1.0.0
 requests==2.19.1
-rsa==3.4.2
+requests-hawk==1.0.0
+rsa==4.0.0
 scriptworker==16.0.1
-signingscript==9.0.3  # puppet: nodownload
+signingscript==9.2.0  # puppet: nodownload
 signtool==3.2.1
 simplejson==3.16.0  # pyup: ignore
 six==1.11.0

--- a/modules/signing_scriptworker/manifests/init.pp
+++ b/modules/signing_scriptworker/manifests/init.pp
@@ -10,6 +10,7 @@ class signing_scriptworker {
     include tweaks::swap_on_instance_storage
     include packages::gcc
     include packages::make
+    include packages::xz_devel
     include tweaks::scriptworkerlogrotate
 
     $env_config          = $signing_scriptworker::settings::env_config[$signing_scriptworker_env]

--- a/modules/signing_scriptworker/templates/dep-passwords.json.erb
+++ b/modules/signing_scriptworker/templates/dep-passwords.json.erb
@@ -18,6 +18,6 @@
         ["mac-v2-signing11.srv.releng.mdc2.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"], "signing_server"],
         ["mac-v2-signing12.srv.releng.mdc2.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"], "signing_server"],
         ["mac-v2-signing13.srv.releng.mdc2.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"], "signing_server"],
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_dep_username"]) %>", "<%= scope.function_secret(["autograph_mar_dep_password"]) %>", ["autograph_mar384"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_dep_username"]) %>", "<%= scope.function_secret(["autograph_mar_dep_password"]) %>", ["autograph_mar384", "autograph_hash_only_mar384"], "autograph"]
     ]
 }

--- a/modules/signing_scriptworker/templates/passwords.json.erb
+++ b/modules/signing_scriptworker/templates/passwords.json.erb
@@ -18,7 +18,7 @@
         ["mac-v2-signing11.srv.releng.mdc2.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"], "signing_server"],
         ["mac-v2-signing12.srv.releng.mdc2.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"], "signing_server"],
         ["mac-v2-signing13.srv.releng.mdc2.mozilla.com:9100", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_nightly_password"]) %>", ["macapp"], "signing_server"],
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_nightly_username"]) %>", "<%= scope.function_secret(["autograph_mar_nightly_password"]) %>", ["autograph_mar384"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_nightly_username"]) %>", "<%= scope.function_secret(["autograph_mar_nightly_password"]) %>", ["autograph_mar384", "autograph_hash_only_mar384"], "autograph"]
     ],
     "<%= @env_config['scope_prefixes'][0] %>cert:dep-signing": [
         ["signing7.srv.releng.mdc1.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["gpg", "sha2signcode", "sha2signcodestub", "osslsigncode", "signcode", "mar", "mar_sha384", "mar_sha384", "jar", "emevoucher", "widevine", "widevine_blessed"], "signing_server"],
@@ -39,7 +39,7 @@
         ["mac-v2-signing11.srv.releng.mdc2.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"], "signing_server"],
         ["mac-v2-signing12.srv.releng.mdc2.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"], "signing_server"],
         ["mac-v2-signing13.srv.releng.mdc2.mozilla.com:9110", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_dep_password"]) %>", ["macapp"], "signing_server"],
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_dep_username"]) %>", "<%= scope.function_secret(["autograph_mar_dep_password"]) %>", ["autograph_mar384"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_dep_username"]) %>", "<%= scope.function_secret(["autograph_mar_dep_password"]) %>", ["autograph_mar384", "autograph_hash_only_mar384"], "autograph"]
     ],
     "<%= @env_config['scope_prefixes'][0] %>cert:release-signing": [
         ["signing7.srv.releng.mdc1.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["gpg", "sha2signcode", "sha2signcodestub", "osslsigncode", "signcode", "mar", "mar_sha384", "jar", "emevoucher", "widevine", "widevine_blessed"], "signing_server"],
@@ -60,6 +60,6 @@
         ["mac-v2-signing11.srv.releng.mdc2.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"], "signing_server"],
         ["mac-v2-signing12.srv.releng.mdc2.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"], "signing_server"],
         ["mac-v2-signing13.srv.releng.mdc2.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["macapp"], "signing_server"],
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_release_username"]) %>", "<%= scope.function_secret(["autograph_mar_release_password"]) %>", ["autograph_mar384"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_release_username"]) %>", "<%= scope.function_secret(["autograph_mar_release_password"]) %>", ["autograph_mar384", "autograph_hash_only_mar384"], "autograph"]
     ]
 }


### PR DESCRIPTION
Add autograph hash-signing support. This patch:

- adds `mar` as a python dependency.
  - also pins `datadog` to 0.17.0 since it's pinned in signingscript. NI'ed @srfraser [to see if we want to keep that pinned](https://github.com/mozilla-releng/signingscript/commit/febe8842da6b5ca00d7fe332caa37bc4f1473925#r30817586).
- adds `xz-devel` as a signing scriptworker package
- bumps us to signingscript 9.2.0, which adds autograph-hash support
- adds the `autograph_hash_only_mar384` format to the passwords templates.