### PR TITLE
move_back_mdc2_nodes_from_gecko-t-linux-talos-tw_to_gecko-t-linux-talos

### DIFF
--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -13,7 +13,20 @@ node /^t-yosemite-r7-\d+\.test\.releng\.(mdc1|mdc2)\.mozilla\.com$/ {
     include toplevel::worker::releng::generic_worker::test::gpu
 }
 
-# Linux on moonshot in mdc1 running taskcluster worker
+# Linux on moonshot in mdc1 running taskcluster worker, but will be migrated to generic worker once bug 1474570 lands
+# ms == moonshot == https://www.hpe.com/emea_europe/en/servers/moonshot.html
+# xe == xen virtual machines on moonshot
+# Now, we have 98 workers from mdc1 in gecko-t-linux-talos-tw queue
+# Workers range:
+# t-linux64-ms-001 - 015 - 15 workers
+# t-linux64-ms-046 - 060 - 15 workers
+# t-linux64-ms-091 - 105 - 15 workers
+# t-linux64-ms-136 - 150 - 15 workers
+# t-linux64-ms-181 - 195 - 15 workers
+# t-linux64-ms-226 - 239 - 14 workers
+# t-linux64-ms-271 - 279 - 9 workers
+# TOTAL = 98 workers
+
 node /^t-linux64-(ms|xe)-\d{3}\.test\.releng\.mdc1\.mozilla\.com$/ {
     $aspects          = [ 'low-security' ]
     $slave_trustlevel = 'try'
@@ -22,23 +35,27 @@ node /^t-linux64-(ms|xe)-\d{3}\.test\.releng\.mdc1\.mozilla\.com$/ {
     include toplevel::worker::releng::taskcluster_worker::test::gpu
 }
 
-# Move some workers from mdc2 into gecko-t-linux-talos-tw queue
-
-node /^t-linux64-(ms|xe)-[3-4][0-9][0-9]\.test\.releng\.mdc2\.mozilla\.com$/ {
-    $aspects          = [ 'low-security' ]
-    $slave_trustlevel = 'try'
-    $taskcluster_worker_type  = 'gecko-t-linux-talos-tw'
-    include fw::profiles::linux_taskcluster_worker
-    include toplevel::worker::releng::taskcluster_worker::test::gpu
-}
-
-# Linux on moonshot in mdc2 running taskcluster-worker, but will be migrated to generic-worker once bug 1474570 lands
+# Linux on moonshot in mdc2 running generic-worker, but will be migrated to generic-worker once bug 1474570 lands
 # The migration is underway such that all taskcluster-worker workload is being moved from worker type
 # gecko-t-linux-talos to gecko-t-linux-talos-tw, and that when that completes, gecko-t-linux-talos will then be used
 # for generic-worker implementation of talos linux tasks. For more details, please see:
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1474570#c32
 
-node /^t-linux64-(ms|xe)-[5][0-9][0-9]\.test\.releng\.mdc2\.mozilla\.com$/ {
+# ms == moonshot == https://www.hpe.com/emea_europe/en/servers/moonshot.html
+# xe == xen virtual machines on moonshot
+
+# Now, we have 88 workers from mdc2 in gecko-t-linux-talos-tw queue
+# Workers range:
+# t-linux64-ms-301 - 315 - 15 workers
+# t-linux64-ms-346 - 360 - 15 workers
+# t-linux64-ms-391 - 405 - 15 workers
+# t-linux64-ms-436 - 450 - 15 workers
+# t-linux64-ms-481 - 495 - 15 workers
+# t-linux64-ms-526 - 540 - 15 workers
+# TOTAL = 90 workers
+
+
+node /^t-linux64-(ms|xe)-\d{3}\.test\.releng\.mdc2\.mozilla\.com$/ {
     $aspects          = [ 'low-security' ]
     $slave_trustlevel = 'try'
     $worker_type  = 'gecko-t-linux-talos'


### PR DESCRIPTION
Move back mdc2 nodes from gecko-t-linux-talos-tw queue to gecko-t-linux-talos queue and run generic-worker