### PR TITLE
unpin datadog

### DIFF
--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -12,7 +12,7 @@ chardet==3.0.4
 click==7.0
 construct==2.9.45
 cryptography==2.3.1
-datadog==0.17.0  # pyup: ignore
+datadog==0.17.0
 decorator==4.3.0
 defusedxml==0.5.0
 dictdiffer==0.7.1


### PR DESCRIPTION
We had this pinned in signingscript, but we should be able to upgrade.
https://github.com/mozilla-releng/signingscript/commit/febe8842da6b5ca00d7fe332caa37bc4f1473925#r30817586