### PR TITLE
Update hg server cert for bug 1495464

### DIFF
--- a/modules/mercurial/templates/hgrc.erb
+++ b/modules/mercurial/templates/hgrc.erb
@@ -33,8 +33,7 @@ robustcheckout=<%=scope.lookupvar('mercurial::settings::hgext_dir')%>/robustchec
 
 
 [hostsecurity]
-hg.mozilla.org:fingerprints = sha256:8E:AD:F7:6A:EB:44:06:15:ED:F3:E4:69:A6:64:60:37:2D:FF:98:88:37:BF:D7:B8:40:84:01:48:9C:26:CE:D9, sha256:81:3D:75:69:E3:76:F8:5B:31:1E:92:C9:CF:56:23:F6:4B:C2:82:77:E3:63:FB:7F:28:65:D0:9A:88:FB:BE:B7
-ftp-ssl.mozilla.org:fingerprints = 9d:8e:3e:7c:4a:33:6f:53:c6:64:a8:48:d3:ea:72:05:f0:73:a4:90
+hg.mozilla.org:fingerprints = sha256:17:38:aa:92:0b:84:3e:aa:8e:52:52:e9:4c:2f:98:a9:0e:bf:6c:3e:e9:15:ff:0a:29:80:f7:06:02:5b:e8:48, sha256:8e:ad:f7:6a:eb:44:06:15:ed:f3:e4:69:a6:64:60:37:2d:ff:98:88:37:bf:d7:b8:40:84:01:48:9c:26:ce:d9
 
 [web]
 <% if scope.lookupvar('::operatingsystem') != 'windows' -%>

--- a/modules/mercurial/templates/mercurial.ini.erb
+++ b/modules/mercurial/templates/mercurial.ini.erb
@@ -81,11 +81,8 @@ traceback = True
 [bundleclone]
 prefers = stream=revlogv1
 
-[hostfingerprints]
-hg.mozilla.org = af:27:b9:34:47:4e:e5:98:01:f6:83:2b:51:c9:aa:d8:df:fb:1a:27
-s3-external-1.amazonaws.com = 44:ae:c0:4d:9e:8d:50:13:fc:c3:0c:27:8c:06:f0:53:8a:ad:d2:22
-s3-us-west-2.amazonaws.com = ad:ab:0d:1e:fe:1c:78:5b:94:f9:76:b2:5a:12:51:9a:12:7b:66:a2
-ftp-ssl.mozilla.org = 9d:8e:3e:7c:4a:33:6f:53:c6:64:a8:48:d3:ea:72:05:f0:73:a4:90
+[hostsecurity]
+hg.mozilla.org:fingerprints = sha256:17:38:aa:92:0b:84:3e:aa:8e:52:52:e9:4c:2f:98:a9:0e:bf:6c:3e:e9:15:ff:0a:29:80:f7:06:02:5b:e8:48, sha256:8e:ad:f7:6a:eb:44:06:15:ed:f3:e4:69:a6:64:60:37:2d:ff:98:88:37:bf:d7:b8:40:84:01:48:9c:26:ce:d9
 ;
 ; Define external diff commands
 ;


### PR DESCRIPTION
Copy and paste from [bug 1495464 comment #6](https://bugzilla.mozilla.org/show_bug.cgi?id=1495464#c6). I'm pretty sure that mercurial.ini is unused now that we don't run any Windows builders but update it to the v3.9+ style config too. 

Also removes ftp-ssl.mozilla.org, which is baffling in an hg config file.