### PR TITLE
add `taskcluster_root_url` to fix taskcluster>=5.0.0

### DIFF
--- a/modules/scriptworker/templates/check_pending_scriptworker_tasks.erb
+++ b/modules/scriptworker/templates/check_pending_scriptworker_tasks.erb
@@ -75,6 +75,9 @@ async def async_main():
         "accessToken": "<%= @taskcluster_access_token %>"
     }
 
+    # fix taskcluster>=5.0.0
+    context.config = {'taskcluster_root_url': 'https://taskcluster.net'}
+
     async with aiohttp.ClientSession(connector=conn) as session:
         context.session = session
         context.credentials = credentials  # this creates a queue


### PR DESCRIPTION
There are probably nicer ways to fix this, but this should get nagios alerts fixed sooner.