### PR TITLE
bug 1499217 - fix l10n bumper

### DIFF
--- a/modules/toplevel/manifests/mixin/l10n_bumper.pp
+++ b/modules/toplevel/manifests/mixin/l10n_bumper.pp
@@ -4,4 +4,12 @@
 
 class toplevel::mixin::l10n_bumper {
     include ::l10n_bumper
+
+    ssh::user_privkey {
+        "ffxbld_rsa":
+            home     => $::users::builder::home,
+            username => $::users::builder::username,
+            group    => $::users::builder::group,
+            key      => hiera("buildmaster_ssh_key_ffxbld_rsa");
+    }
 }


### PR DESCRIPTION
This isn't pretty, but this fixes the missing ssh key until we can move
l10n bumper to treescript.

Fixes the bustage from #225.

Tested on bm01.