### PR TITLE
Bug 1486089 - part 1: Bump scriptworker to 16.2.1 on beetmover_script…

### DIFF
--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -32,7 +32,7 @@ python-gnupg==0.4.3
 redo==2.0
 requests==2.19.1
 s3transfer==0.1.13
-scriptworker==16.1.0
+scriptworker==16.2.1
 six==1.11.0
 slugid==1.0.7
 taskcluster==5.0.0


### PR DESCRIPTION
…worker

This was tested against my environment at https://tools.taskcluster.net/groups/CELBgJhTSaecLcB6g5kSQw/tasks/FEIGhT8DSluB4--ubSm3RA/runs/0/logs/public%2Flogs%2Fchain_of_trust.log#L65 