### PR TITLE
Bug 1492245 - part 1: Allow Focus signing via autograph

### DIFF
--- a/modules/signing_scriptworker/templates/passwords-mobile.json.erb
+++ b/modules/signing_scriptworker/templates/passwords-mobile.json.erb
@@ -5,7 +5,8 @@
         ["signing9.srv.releng.mdc1.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["focus-jar"], "signing_server"],
         ["signing10.srv.releng.mdc2.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["focus-jar"], "signing_server"],
         ["signing11.srv.releng.mdc2.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["focus-jar"], "signing_server"],
-        ["signing12.srv.releng.mdc2.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["focus-jar"], "signing_server"]
+        ["signing12.srv.releng.mdc2.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["focus-jar"], "signing_server"],
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_focus_prod_username"]) %>", "<%= scope.function_secret(["autograph_focus_prod_password"]) %>", ["autograph_focus"], "autograph"]
     ],
     "project:mobile:fenix:releng:signing:cert:release-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_fenix_prod_username"]) %>", "<%= scope.function_secret(["autograph_fenix_prod_password"]) %>", ["autograph_fenix"], "autograph"]


### PR DESCRIPTION
After making this patch, I realized I need to update the decision task in Focus too. Signingscript know whether to contact autograph only if the format starts with `autograph_`: https://github.com/mozilla-releng/signingscript/blob/eb321067005541f3fcdf65e9375aef7f4f20ff5f/signingscript/utils.py#L169 