### PR TITLE
Add another mobile-beetmoverworker instance for staging purposes.

### DIFF
--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -422,7 +422,7 @@ node /^tb-beetmover-dev\d+\.srv\.releng\..*\.mozilla\.com$/ {
 }
 #
 # https://github.com/mozilla-mobile workers.
-node mobile-beetmover-2.srv.releng.use1.mozilla.com {
+node mobile-beetmover-2\.srv\.releng\.use1\.mozilla\.com {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'mobile-dev'
     $timezone            = 'UTC'

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -422,7 +422,7 @@ node /^tb-beetmover-dev\d+\.srv\.releng\..*\.mozilla\.com$/ {
 }
 #
 # https://github.com/mozilla-mobile workers.
-node mobile-beetmover-2\.srv\.releng\.use1\.mozilla\.com {
+node /^mobile-beetmover-2\.srv\.releng\.use1\.mozilla\.com$ {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'mobile-dev'
     $timezone            = 'UTC'

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -422,7 +422,7 @@ node /^tb-beetmover-dev\d+\.srv\.releng\..*\.mozilla\.com$/ {
 }
 #
 # https://github.com/mozilla-mobile workers.
-node /^mobile-beetmover-2\.srv\.releng\.use1\.mozilla\.com$ {
+node /^mobile-beetmover-2\.srv\.releng\.use1\.mozilla\.com$/ {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'mobile-dev'
     $timezone            = 'UTC'

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -420,6 +420,15 @@ node /^tb-beetmover-dev\d+\.srv\.releng\..*\.mozilla\.com$/ {
     $only_user_ssh       = true
     include toplevel::server::beetmoverscriptworker
 }
+#
+# https://github.com/mozilla-mobile workers.
+node mobile-beetmover-2.srv.releng.use1.mozilla.com {
+    $aspects             = [ 'maximum-security' ]
+    $beetmoverworker_env = 'mobile-dev'
+    $timezone            = 'UTC'
+    $only_user_ssh       = true
+    include toplevel::server::beetmoverscriptworker
+}
 
 # https://github.com/mozilla-mobile workers.
 node /^mobile-beetmover-\d*\.srv\.releng\..*\.mozilla\.com$/ {


### PR DESCRIPTION
@JohanLorenzo: I've ramped-up mobile-beetmover2 in the same `use1` region to have something to test our snapshots work. I'll likely ramp-up another one ready for production use or so. 

Does this pinning work well or do you think we should assign it a different DNS and reconfigure to be more intuitive?

I'm thinking we could always revert this and switch it to the production pool if we ever wanted a larger one or redesign its purposes. 