### PR TITLE
Bug 1492245 - Bump signingscript to 9.5.1

### DIFF
--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -37,7 +37,7 @@ requests==2.20.1
 requests-hawk==1.0.0
 rsa==4.0
 scriptworker==16.2.1
-signingscript==9.5.0  # puppet: nodownload
+signingscript==9.5.1  # puppet: nodownload
 signtool==3.2.1
 simplejson==3.16.0  # pyup: ignore
 six==1.11.0


### PR DESCRIPTION
Depends on https://github.com/mozilla-releng/signingscript/pull/95 