### PR TITLE
Updates pushapk product names to have hyphens, not underscores

### DIFF
--- a/modules/pushapk_scriptworker/manifests/init.pp
+++ b/modules/pushapk_scriptworker/manifests/init.pp
@@ -95,14 +95,14 @@ class pushapk_scriptworker {
         }
         'mobile-dep': {
             file {
-                $google_play_config['reference_browser']['certificate_target_location']:
-                    content     => $google_play_config['reference_browser']['certificate'];
+                $google_play_config['reference-browser']['certificate_target_location']:
+                    content     => $google_play_config['reference-browser']['certificate'];
             }
         }
         'mobile-prod': {
             file {
-                $google_play_config['reference_browser']['certificate_target_location']:
-                    content     => $google_play_config['reference_browser']['certificate'];
+                $google_play_config['reference-browser']['certificate_target_location']:
+                    content     => $google_play_config['reference-browser']['certificate'];
                 $google_play_config['focus']['certificate_target_location']:
                     content     => $google_play_config['focus']['certificate'];
             }

--- a/modules/pushapk_scriptworker/manifests/jarsigner_init.pp
+++ b/modules/pushapk_scriptworker/manifests/jarsigner_init.pp
@@ -60,7 +60,7 @@ class pushapk_scriptworker::jarsigner_init {
             }
 
             java_ks {
-                'reference_browser':
+                'reference-browser':
                     certificate => $reference_browser;
             }
         }
@@ -78,7 +78,7 @@ class pushapk_scriptworker::jarsigner_init {
             java_ks {
                 'focus':
                     certificate => $focus;
-                'reference_browser':
+                'reference-browser':
                     certificate => $reference_browser;
             }
         }

--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -148,27 +148,27 @@ class pushapk_scriptworker::settings {
         }
         'mobile-dep': {
             $google_play_config = {
-                'reference_browser'  => {
+                'reference-browser'  => {
                     service_account             => 'dummy',
                     certificate                 => 'dummy',
                     certificate_target_location => "${root}/dep.p12",
                 },
             }
             $google_play_accounts_config_content = {
-                'reference_browser' => {
+                'reference-browser' => {
                   'service_account' => 'dummy',
                   'certificate' => 'dummy',
                 },
             }
             $jarsigner_certificate_aliases_content = {
-                'reference_browser' => 'reference_browser',
+                'reference-browser' => 'reference-browser',
             }
         }
         'mobile-prod': {
             $google_play_config = {
-                'reference_browser' => {
-                    service_account             => $_google_play_accounts['reference_browser']['service_account'],
-                    certificate                 => $_google_play_accounts['reference_browser']['certificate'],
+                'reference-browser' => {
+                    service_account             => $_google_play_accounts['reference-browser']['service_account'],
+                    certificate                 => $_google_play_accounts['reference-browser']['certificate'],
                     certificate_target_location => "${root}/reference_browser.p12",
                 },
                 'focus'  => {
@@ -178,9 +178,9 @@ class pushapk_scriptworker::settings {
                 },
             }
             $google_play_accounts_config_content = {
-                'reference_browser' => {
-                    'service_account' => $google_play_config['reference_browser']['service_account'],
-                    'certificate' => $google_play_config['reference_browser']['certificate_target_location'],
+                'reference-browser' => {
+                    'service_account' => $google_play_config['reference-browser']['service_account'],
+                    'certificate' => $google_play_config['reference-browser']['certificate_target_location'],
                 },
                 'focus' => {
                     'service_account' => $google_play_config['focus']['service_account'],
@@ -189,7 +189,7 @@ class pushapk_scriptworker::settings {
             }
             $jarsigner_certificate_aliases_content = {
                 'focus' => 'focus',
-                'reference_browser' => 'reference_browser'
+                'reference-browser' => 'reference-browser'
             }
         }
         default: {


### PR DESCRIPTION
When extracting product name from scopes, hyphens are used. Therefore, product names are made of hyphens, not underscores.