### PR TITLE
Updates Pushapk dep g_p_a_config_content to always reference g_p_config

### DIFF
--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -100,8 +100,8 @@ class pushapk_scriptworker::settings {
             }
             $google_play_accounts_config_content = {
                 'dep' => {
-                  'service_account' => 'dummy',
-                  'certificate' => 'dummy',
+                  'service_account' => $google_play_config['dep']['service_account'],
+                  'certificate' => $google_play_config['dep']['certificate_target_location'],
                 }
             }
             $jarsigner_certificate_aliases_content = {
@@ -156,8 +156,8 @@ class pushapk_scriptworker::settings {
             }
             $google_play_accounts_config_content = {
                 'reference-browser' => {
-                  'service_account' => 'dummy',
-                  'certificate' => 'dummy',
+                  'service_account' => $google_play_config['reference-browser']['service_account'],
+                  'certificate' => $google_play_config['reference-browser']['certificate_target_location'],
                 },
             }
             $jarsigner_certificate_aliases_content = {


### PR DESCRIPTION
`$google_play_accounts_config_content` should always refer to content from `$google_play_config`, even for dep.
The issue this resolves is that `dep`'s `certificate` should point to a real file, not "dummy", and the `dep` `$google_play_config` properly specifies a real file