### PR TITLE
Uses underscores for hiera content

### DIFF
--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -167,8 +167,8 @@ class pushapk_scriptworker::settings {
         'mobile-prod': {
             $google_play_config = {
                 'reference-browser' => {
-                    service_account             => $_google_play_accounts['reference-browser']['service_account'],
-                    certificate                 => $_google_play_accounts['reference-browser']['certificate'],
+                    service_account             => $_google_play_accounts['reference_browser']['service_account'],
+                    certificate                 => $_google_play_accounts['reference_browser']['certificate'],
                     certificate_target_location => "${root}/reference_browser.p12",
                 },
                 'focus'  => {


### PR DESCRIPTION
I replaced all `reference-browser` usages to use `-`, just like how the product is represented in scopes. However, hiera secrets' keys should use underscores, not dashes. This PR properly makes sure that `-` and `_` are used consistently throughout `pushapk_scriptworker`