### PR TITLE
reference-browser: Fix signing format

### DIFF
--- a/modules/signing_scriptworker/templates/passwords-mobile.json.erb
+++ b/modules/signing_scriptworker/templates/passwords-mobile.json.erb
@@ -12,6 +12,6 @@
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_fenix_prod_username"]) %>", "<%= scope.function_secret(["autograph_fenix_prod_password"]) %>", ["autograph_fenix"], "autograph"]
     ],
     "project:mobile:reference-browser:releng:signing:cert:release-signing": [
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_reference_browser_prod_username"]) %>", "<%= scope.function_secret(["autograph_reference_browser_prod_password"]) %>", ["autograph_reference_browser"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_reference_browser_prod_username"]) %>", "<%= scope.function_secret(["autograph_reference_browser_prod_password"]) %>", ["autograph_apk_reference_browser"], "autograph"]
     ]
 }


### PR DESCRIPTION
Before this patch: https://tools.taskcluster.net/groups/MddUus-YTaGD80Vfqk1fXA/tasks/SFSLXBWFTmGERPahGhRZ2Q/runs/0/logs/public%2Flogs%2Flive_backing.log#L26
After: https://tools.taskcluster.net/groups/MddUus-YTaGD80Vfqk1fXA/tasks/SFSLXBWFTmGERPahGhRZ2Q/runs/1/logs/public%2Flogs%2Flive_backing.log#L14

I manually edited the file on the worker to get the second run passing. r? @mitchhentges