### PR TITLE
Bug 1515335 - win64 asan failing to sign xul.dll due to size.

### DIFF
--- a/modules/signingserver/manifests/instance.pp
+++ b/modules/signingserver/manifests/instance.pp
@@ -15,7 +15,7 @@ define signingserver::instance(
         $concurrency        = 4,
         # When signcode_maxsize changes, please inform
         # secops+fx-sig-verify@m.c as they have similar limit.
-        $signcode_maxsize   = 367001600) {
+        $signcode_maxsize   = 378420000) {
     include config
     include signingserver::base
     include users::signer


### PR DESCRIPTION
Bump by current attempt (370,758,144.00) rounded to 371,000,000. with an extra 2% added ontop.

This is similar in mindset to 1417497