### PR TITLE
Revert "Removes schema_file from pushapk config"

### DIFF
--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -68,6 +68,7 @@ class pushapk_scriptworker::settings {
     }
 
     $_env_config                         = $_env_configs[$pushapk_scriptworker_env]
+    $schema_file                         = "${root}/lib/python${python3_virtualenv_version}/site-packages/pushapkscript/data/pushapk_task_schema.json"
     $work_dir                            = "${root}/work"
     $task_script                         = "${root}/bin/pushapkscript"
 
@@ -213,6 +214,7 @@ class pushapk_scriptworker::settings {
     $script_config                       = "${root}/script_config.json"
     $script_config_content = {
         'work_dir'   => $work_dir,
+        'schema_file'=> $schema_file,
         'verbose'    => $verbose_logging,
 
         'google_play_accounts' => $google_play_accounts_config_content,


### PR DESCRIPTION
Reverts mozilla-releng/build-puppet#343 because of bug 1516105, it broke publishing to the play store. 