### PR TITLE
[suggestion] Adds mhentges to shortlist

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -207,6 +207,7 @@ class config inherits config::base {
         'catlee',
         'jlorenzo',
         'jwood',
+        'mhentges',
         'mtabara',
         'nthomas',
         'raliiev',


### PR DESCRIPTION
This isn't _currently_ affecting me.

However, if I need to debug issues/test configuration with the signing workers, I can't ssh into them to apply them to my custom environment.
If I was on this shortlist, this would be possible.

**Alternatives:**
* Spin up a new machine (e.g.: `dep-m-signing-linux-$n`) whenever I need to apply my custom environment to a machine I don't have SSH access to
* Bug a releng-er with access to pin my environment to the machine on behalf of me, then I'll set it back after
* Get PR into `build-puppet` to pin my environment to machine (still blocked on another relenger), wait for changes to propagate, perform my debugging/testing, PR into `build-puppet` to remove pin after

