### PR TITLE
bump scriptworker to 17.1.0

### DIFF
--- a/modules/addon_scriptworker/files/requirements.txt
+++ b/modules/addon_scriptworker/files/requirements.txt
@@ -26,7 +26,7 @@ python-gnupg==0.4.3
 python-jose==3.0.1
 requests==2.21.0
 rsa==4.0
-scriptworker==17.0.1
+scriptworker==17.1.0
 six==1.12.0
 slugid==1.0.7
 taskcluster==6.0.0

--- a/modules/balrog_scriptworker/files/requirements-3.txt
+++ b/modules/balrog_scriptworker/files/requirements-3.txt
@@ -20,7 +20,7 @@ ptyprocess==0.6.0
 python-dateutil==2.7.5
 python-gnupg==0.4.3
 requests==2.21.0
-scriptworker==17.0.1
+scriptworker==17.1.0
 six==1.12.0
 slugid==1.0.7
 taskcluster==6.0.0

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -32,7 +32,7 @@ python-gnupg==0.4.3
 redo==2.0.2
 requests==2.21.0
 s3transfer==0.1.13
-scriptworker==17.0.1
+scriptworker==17.1.0
 six==1.12.0
 slugid==1.0.7
 taskcluster==6.0.0

--- a/modules/bouncer_scriptworker/files/requirements.txt
+++ b/modules/bouncer_scriptworker/files/requirements.txt
@@ -22,7 +22,7 @@ ptyprocess==0.6.0
 python-dateutil==2.7.5
 python-gnupg==0.4.3
 requests==2.21.0
-scriptworker==17.0.1
+scriptworker==17.1.0
 six==1.12.0
 slugid==1.0.7
 taskcluster==6.0.0

--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -60,7 +60,7 @@ python-gnupg==0.4.3
 pytz==2018.7
 requests==2.21.0
 rsa==4.0
-scriptworker==17.0.1
+scriptworker==17.1.0
 simplegeneric==0.8.1
 slugid==1.0.7
 taskcluster==6.0.0

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -34,7 +34,7 @@ pyxdg==0.25
 requests==2.9.1
 requests-toolbelt==0.6.0
 requests-unixsocket==0.1.5
-scriptworker==16.1.0
+scriptworker==17.1.0
 simplejson==3.8.2
 six==1.11.0
 slugid==1.0.7

--- a/modules/shipit_scriptworker/files/requirements.txt
+++ b/modules/shipit_scriptworker/files/requirements.txt
@@ -21,7 +21,7 @@ python-dateutil==2.7.5
 python-gnupg==0.4.3
 redo==2.0.2
 requests==2.21.0
-scriptworker==17.0.1
+scriptworker==17.1.0
 shipitapi==2.0.0
 six==1.12.0
 slugid==1.0.7

--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -36,7 +36,7 @@ python-jose==3.0.1
 requests==2.21.0
 requests-hawk==1.0.0
 rsa==4.0
-scriptworker==17.0.1
+scriptworker==17.1.0
 signingscript==9.5.1  # puppet: nodownload
 signtool==3.2.1
 simplejson==3.16.0  # pyup: ignore

--- a/modules/transparency_scriptworker/files/requirements.txt
+++ b/modules/transparency_scriptworker/files/requirements.txt
@@ -21,7 +21,7 @@ python-dateutil==2.7.5
 python-gnupg==0.4.3
 redo==2.0.2
 requests==2.21.0
-scriptworker==17.0.1
+scriptworker==17.1.0
 six==1.12.0
 slugid==1.0.7
 taskcluster==6.0.0

--- a/modules/tree_scriptworker/files/requirements.txt
+++ b/modules/tree_scriptworker/files/requirements.txt
@@ -20,7 +20,7 @@ ptyprocess==0.6.0
 python-dateutil==2.7.5
 python-gnupg==0.4.3
 requests==2.21.0
-scriptworker==17.0.1
+scriptworker==17.1.0
 six==1.12.0
 slugid==1.0.7
 taskcluster==6.0.0


### PR DESCRIPTION
This will roll out release promotion action hook support. [changelog](https://github.com/mozilla-releng/scriptworker/pull/286/commits/c8c416e70e3e796449c639876a9dd12307829512#diff-4ac32a78649ca5bdd8e0ba38b7006a1e)