### PR TITLE
Adds more-open mobile_shortlist for mobile signing workers

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -213,9 +213,29 @@ class config inherits config::base {
         'sfraser',
     ]
 
+    $mobile_shortlist = [
+        # relops
+        'klibby',
+        'jwatkins',
+        'dhouse',
+
+        # releng
+        'asasaki',
+        'bhearsum',
+        'catlee',
+        'jlorenzo',
+        'jwood',
+        'mhentges',
+        'mtabara',
+        'nthomas',
+        'raliiev',
+        'sfraser',
+    ]
+
     $admin_users                     = $::fqdn ? {
         /^rejh\d\.srv\.releng\.(mdc1|mdc2)\.mozilla.com/  => $jumphost_admin_users,
         # signing machines have a very limited access list
+        /^(dep-m|mobil)-signing.*/                             => $mobile_shortlist,
         /^.*sign.*/                                            => $shortlist,
         default                                                => hiera('ldap_admin_users',
                                                                     # backup to ensure access in cas'e the sync fails:

--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -236,7 +236,7 @@ class config inherits config::base {
         /^rejh\d\.srv\.releng\.(mdc1|mdc2)\.mozilla.com/  => $jumphost_admin_users,
         # signing machines have a very limited access list
         /^(dep-m|mobil)-signing.*/                             => $mobile_shortlist,
-        /^.*sign.*/                                            => $shortlist,
+        /^(?!(dep-m|mobil)-signing).*sign.*/                   => $shortlist,
         default                                                => hiera('ldap_admin_users',
                                                                     # backup to ensure access in cas'e the sync fails:
                                                                     ['klibby', 'jwatkins'])


### PR DESCRIPTION
`mobile_shortlist` is equivalent to `shortlist`, plus `mhentges` added