### PR TITLE
Bug 1368484 - part 2: Bump mozapkpublisher to 0.13.0

### DIFF
--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -39,7 +39,7 @@ kiwisolver==1.0.1
 lxml==4.3.0
 matplotlib==3.0.2
 mohawk==0.3.4
-mozapkpublisher==0.12.0
+mozapkpublisher==0.13.0
 mozilla-version==0.3.1
 multidict==4.5.2
 networkx==2.2


### PR DESCRIPTION
This package passed at https://tools.taskcluster.net/groups/frz3aHJdTGOgKx7xCDKkmw/tasks/COm1E5W_Tc2K4Cerkorg6Q/runs/2/logs/public%2Flogs%2Flive_backing.log#L206 