### PR TITLE
remove t-yosemite-r7-189 from roller config

### DIFF
--- a/modules/roller/templates/prod/worker_config.json.erb
+++ b/modules/roller/templates/prod/worker_config.json.erb
@@ -584,7 +584,6 @@
     "t-yosemite-r7-186": { "fqdn": "t-yosemite-r7-186.test.releng.mdc2.mozilla.com", "bug_cc":"dhouse@mozilla.com", "pdu": "pdu1.gc132.ops.releng.mdc2.mozilla.com:aa2" },
     "t-yosemite-r7-187": { "fqdn": "t-yosemite-r7-187.test.releng.mdc2.mozilla.com", "bug_cc":"dhouse@mozilla.com", "pdu": "pdu1.gc132.ops.releng.mdc2.mozilla.com:ba2" },
     "t-yosemite-r7-188": { "fqdn": "t-yosemite-r7-188.test.releng.mdc2.mozilla.com", "bug_cc":"dhouse@mozilla.com", "pdu": "pdu1.gc132.ops.releng.mdc2.mozilla.com:aa3" },
-    "t-yosemite-r7-189": { "fqdn": "t-yosemite-r7-189.test.releng.mdc2.mozilla.com", "bug_cc":"dhouse@mozilla.com", "pdu": "pdu1.gc132.ops.releng.mdc2.mozilla.com:ba3" },
     "t-yosemite-r7-190": { "fqdn": "t-yosemite-r7-190.test.releng.mdc2.mozilla.com", "bug_cc":"dhouse@mozilla.com", "pdu": "pdu1.gc132.ops.releng.mdc2.mozilla.com:aa4" },
     "t-yosemite-r7-191": { "fqdn": "t-yosemite-r7-191.test.releng.mdc2.mozilla.com", "bug_cc":"dhouse@mozilla.com", "pdu": "pdu1.gc132.ops.releng.mdc2.mozilla.com:ba4" },
     "t-yosemite-r7-192": { "fqdn": "t-yosemite-r7-192.test.releng.mdc2.mozilla.com", "bug_cc":"dhouse@mozilla.com", "pdu": "pdu1.gc132.ops.releng.mdc2.mozilla.com:ba5" },


### PR DESCRIPTION
mac #189 is broken (no display) and off warranty
https://bugzilla.mozilla.org/show_bug.cgi?id=1472510