### PR TITLE
Bumps supervisord time before scriptworker is killed

### DIFF
--- a/modules/scriptworker/templates/supervisor_config.erb
+++ b/modules/scriptworker/templates/supervisor_config.erb
@@ -4,3 +4,7 @@ redirect_stderr=true
 stdout_logfile=syslog
 autorestart=true
 autostart=true
+
+# scriptworker needs to report "worker shutdown" to Taskcluster
+# on shutdown. The default of 10 seconds is too short
+stopwaitsecs=30


### PR DESCRIPTION
Until [this PR](https://github.com/mozilla-releng/scriptworker/pull/310) is merged, this will just delay puppet sync times.
After that PR is merged, this allows "worker shutdown" to be propagated to Taskcluster