### PR TITLE
Revert "Bug 1489603: restart mig if exists"

### DIFF
--- a/modules/mig/manifests/agent/daemon.pp
+++ b/modules/mig/manifests/agent/daemon.pp
@@ -19,14 +19,10 @@ class mig::agent::daemon {
             case $::operatingsystemrelease {
                 16.04: {
                     exec {
-                        # mig hangs sometimes after a package upgrade
-                        # so let systemd handle restarting it after an upgrade
-                        'systemd restart mig':
-                            command     => '/bin/systemctl restart mig-agent.service',
-                            subscribe   => Class['packages::mozilla::mig_agent'],
-                            refreshonly => true,
-                            # is-active returns false if the service is inactive or does not exist
-                            onlyif      => '/bin/systemctl is-active mig-agent.service',
+                        'kill mig':
+                            command   => "/bin/kill -s 2 $(${mig_path} -q=pid); ${mig_path}",
+                            subscribe => Class['packages::mozilla::mig_agent'],
+                            notify    => Service['mig-agent']
                     }
                     service {
                         'mig-agent':


### PR DESCRIPTION
Reverts mozilla-releng/build-puppet#240

This worked-around the MIG server(s) being down, but blocks newly imaged machines until mig-agent is manually executed.
Back-out to previous state: will fail if the MIG servers go down, but will not block new machines from starting.