### PR TITLE
Bumps supervisord time between terminating and killing scriptworker

### DIFF
--- a/modules/scriptworker/templates/supervisor_config.erb
+++ b/modules/scriptworker/templates/supervisor_config.erb
@@ -4,3 +4,7 @@ redirect_stderr=true
 stdout_logfile=syslog
 autorestart=true
 autostart=true
+
+# scriptworker needs to report "worker shutdown" to Taskcluster
+# on shutdown. The default of 10 seconds is too short
+stopwaitsecs=30


### PR DESCRIPTION
[We backed out this commit earlier](https://github.com/mozilla-releng/build-puppet/commit/55460dcd27b4eac26eda648cfa4081f8b234990b), but that turned out to be due to [timing, not the contents themselves](https://bugzilla.mozilla.org/show_bug.cgi?id=1529432)