### PR TITLE
Bumps beetmover max zip file size to 100mb

### DIFF
--- a/modules/beetmover_scriptworker/templates/script_config.json.erb
+++ b/modules/beetmover_scriptworker/templates/script_config.json.erb
@@ -10,7 +10,7 @@
 
     "verbose": <%= scope.lookupvar("beetmover_scriptworker::settings::verbose_logging") %>,
 
-    "zip_max_file_size_in_mb": 100,
+    "zip_max_file_size_in_mb": 300,
 
     "bucket_config": {
 <% if @env_config["nightly_buckets"] -%>


### PR DESCRIPTION
This is for [this ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1522581). An earlier fix for the issue bumped the default maximum file size, but we missed the explicit override in puppet.

Since we don't _want_ a different maximum size, perhaps we can just lean on the default instead?
(If we'd rather be explicit in puppet, we should remove the default from `beetmover` and make it "required", imho)