### PR TITLE
Perma Failing signing nightly asan

### DIFF
--- a/modules/signingserver/manifests/instance.pp
+++ b/modules/signingserver/manifests/instance.pp
@@ -15,7 +15,7 @@ define signingserver::instance(
         $concurrency        = 4,
         # When signcode_maxsize changes, please inform
         # secops+fx-sig-verify@m.c as they have similar limit.
-        $signcode_maxsize   = 378420000) {
+        $signcode_maxsize   = 416262000) {
     include config
     include signingserver::base
     include users::signer


### PR DESCRIPTION

Bug 1530127
Perma signingscript.exceptions.FailedSubprocess: Command `/builds/scriptworker/bin/signtool -v -n /builds/scriptworker/work/nonce -t /builds/scriptworker/work/token ... builds/scriptworker/work/zipkaeu9jdb/firefox/xul.dll` failed
