### PR TITLE
roll out scriptworker 22 with ed25519

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -494,6 +494,7 @@ class config inherits config::base {
     $scriptworker_root                        = '/builds/scriptworker' # Used by scriptworker instances
     $scriptworker_gpg_private_key             = secret('scriptworker_gpg_private_key')
     $scriptworker_gpg_public_key              = secret('scriptworker_gpg_public_key')
+    $scriptworker_ed25519_private_key         = secret('scriptworker_ed25519_private_key')
 
     $l10n_bumper_env_config = {
         'mozilla-central' => {

--- a/modules/addon_scriptworker/files/requirements.txt
+++ b/modules/addon_scriptworker/files/requirements.txt
@@ -9,8 +9,7 @@ attrs==19.1.0
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+cryptography==2.6.1
 defusedxml==0.5.0
 dictdiffer==0.7.2
 ecdsa==0.13
@@ -20,26 +19,28 @@ github3.py==1.3.0
 idna==2.8
 idna_ssl==1.1.0
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
-mohawk==0.3.4 # pyup: ignore
+mohawk==0.3.4  # pyup: ignore
 multidict==4.5.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pyasn1==0.4.5
 pycparser==2.19
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 python-jose==3.0.1
 requests==2.21.0
 rsa==4.0
-scriptworker==21.0.0
+scriptworker==22.0.0
 six==1.12.0
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
+wheel==0.33.1
 yarl==1.3.0

--- a/modules/balrog_scriptworker/files/requirements-3.txt
+++ b/modules/balrog_scriptworker/files/requirements-3.txt
@@ -8,8 +8,7 @@ attrs==19.1.0
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+cryptography==2.6.1
 defusedxml==0.5.0
 dictdiffer==0.7.2
 frozendict==1.2
@@ -17,23 +16,25 @@ github3.py==1.3.0
 idna==2.8
 idna_ssl==1.1.0
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
-mohawk==0.3.4 # pyup: ignore
+mohawk==0.3.4  # pyup: ignore
 multidict==4.5.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pycparser==2.19
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 requests==2.21.0
-scriptworker==21.0.0
+scriptworker==22.0.0
 six==1.12.0
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
+wheel==0.33.1
 yarl==1.3.0

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -8,14 +8,13 @@ asn1crypto==0.24.0
 async_timeout==3.0.1
 attrs==19.1.0
 beetmoverscript==8.4.1  # puppet: nodownload
-boto3==1.9.108
-botocore==1.12.108
+boto3==1.9.110
+botocore==1.12.110
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
 click==7.0
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+cryptography==2.6.1
 defusedxml==0.5.0
 dictdiffer==0.7.2
 docutils==0.14
@@ -26,28 +25,30 @@ idna_ssl==1.1.0
 incremental==17.5.0
 jmespath==0.9.4
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
-mohawk==0.3.4 # pyup: ignore
+mohawk==0.3.4  # pyup: ignore
 mozilla-version==0.3.1
 multidict==4.5.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pycparser==2.19
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 redo==2.0.2
 requests==2.21.0
 s3transfer==0.2.0
-scriptworker==21.0.0
+scriptworker==22.0.0
 six==1.12.0
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 toml==0.10.0
 towncrier==19.2.0
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
+wheel==0.33.1
 yarl==1.3.0

--- a/modules/bouncer_scriptworker/files/requirements.txt
+++ b/modules/bouncer_scriptworker/files/requirements.txt
@@ -9,8 +9,7 @@ bouncerscript==3.5.0  # puppet: nodownload
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+cryptography==2.6.1
 defusedxml==0.5.0
 dictdiffer==0.7.2
 frozendict==1.2
@@ -18,24 +17,26 @@ github3.py==1.3.0
 idna==2.8
 idna_ssl==1.1.0
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
-mohawk==0.3.4 # pyup: ignore
+mohawk==0.3.4  # pyup: ignore
 mozilla-version==0.3.1
 multidict==4.5.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pycparser==2.19
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 requests==2.21.0
-scriptworker==21.0.0
+scriptworker==22.0.0
 six==1.12.0
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
+wheel==0.33.1
 yarl==1.3.0

--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -17,8 +17,7 @@ cffi==1.12.2
 chardet==3.0.4
 click==7.0
 colorama==0.4.1
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+cryptography==2.6.1
 Cycler==0.10.0
 decorator==4.3.2
 defusedxml==0.5.0
@@ -37,12 +36,12 @@ ipython==7.3.0
 ipython_genutils==0.2.0
 jedi==0.13.3
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
 kiwisolver==1.0.1
 lxml==4.3.2
 matplotlib==3.0.3
-mohawk==0.3.4 # pyup: ignore
+mohawk==0.3.4  # pyup: ignore
 mozapkpublisher==1.0.1
 mozilla-version==0.3.1
 multidict==4.5.2
@@ -61,16 +60,17 @@ pycparser==2.19
 pydot==1.4.1
 pyOpenSSL==19.0.0
 pyparsing==2.3.1
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 pytz==2018.9
 requests==2.21.0
 rsa==4.0
-scriptworker==21.0.0
+scriptworker==22.0.0
 simplegeneric==0.8.1
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 traitlets==4.3.2
 typing-extensions==3.7.2
 uritemplate==3.0.0
@@ -78,4 +78,5 @@ urllib3==1.24.1
 virtualenv==16.4.3
 voluptuous==0.11.5
 wcwidth==0.1.7
+wheel==0.33.1
 yarl==1.3.0

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -3,31 +3,30 @@
 # Please do not update this file without end-to-end testing. pushsnapscript has a major hack in its
 # dependencies. Please read https://bugzilla.mozilla.org/show_bug.cgi?id=1447263#c15 for context.
 PyYAML==3.13
-aiohttp==3.4.4
-arrow==0.12.1
+aiohttp==3.5.4
+arrow==0.13.1
 asn1crypto==0.24.0
-async_timeout==3.0.0
-attrs==18.2.0
+async_timeout==3.0.1
+attrs==19.1.0
 certifi==2018.11.29
-cffi==1.11.5
+cffi==1.12.2
 chardet==3.0.4
-click==6.7
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+click==7.0
+cryptography==2.6.1
 defusedxml==0.5.0
-dictdiffer==0.7.1
+dictdiffer==0.7.2
 frozendict==1.2
 github3.py==1.3.0
 idna==2.8
 idna_ssl==1.1.0
-json-e==2.7.0
-jsonschema==2.6.0
+json-e==3.0.0
+jsonschema==3.0.1
 jwcrypto==0.6.0
 # Puppet check is deactivated because it requires some distro library (libsodium) to be installed.
 libnacl==1.3.6    # puppet: nodownload
 mohawk==0.3.4
-mozilla-version==0.3.0
-multidict==4.4.2
+mozilla-version==0.3.1
+multidict==4.5.2
 pexpect==4.6.0
 progressbar33==2.4
 ptyprocess==0.6.0
@@ -36,21 +35,24 @@ pycparser==2.19
 pyelftools==0.24
 # Puppet check is deactivated because it requires some distro library (libsodium) to be installed.
 pymacaroons==0.9.2    # puppet: nodownload
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-debian==0.1.28
-python-gnupg==0.4.3
+python-gnupg==0.4.4
 pyxdg==0.25
 requests==2.21.0
 requests-toolbelt==0.6.0
 requests-unixsocket==0.1.5
-scriptworker==21.0.0
+scriptworker==22.0.0
 simplejson==3.8.2
 six==1.12.0
 slugid==1.0.7
 tabulate==0.7.5
-taskcluster==5.0.0
-taskcluster-urls==10.1.0
+taskcluster==6.0.0
+taskcluster-urls==11.0.0
+typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
-virtualenv==16.0.0
-yarl==1.2.6
+virtualenv==16.4.1
+wheel==0.33.1
+yarl==1.3.0

--- a/modules/pushsnap_scriptworker/files/requirements.txt
+++ b/modules/pushsnap_scriptworker/files/requirements.txt
@@ -11,7 +11,7 @@ attrs==19.1.0
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
-click==7.0
+click==6.7  # pyup: ignore
 cryptography==2.6.1
 defusedxml==0.5.0
 dictdiffer==0.7.2
@@ -23,7 +23,7 @@ json-e==3.0.0
 jsonschema==3.0.1
 jwcrypto==0.6.0
 # Puppet check is deactivated because it requires some distro library (libsodium) to be installed.
-libnacl==1.3.6    # puppet: nodownload
+libnacl==1.3.6  # puppet: nodownload
 mohawk==0.3.4
 mozilla-version==0.3.1
 multidict==4.5.2
@@ -34,7 +34,7 @@ pushsnapscript==0.2.6  # puppet: nodownload
 pycparser==2.19
 pyelftools==0.24
 # Puppet check is deactivated because it requires some distro library (libsodium) to be installed.
-pymacaroons==0.9.2    # puppet: nodownload
+pymacaroons==0.9.2  # puppet: nodownload
 pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-debian==0.1.28

--- a/modules/scriptworker/manifests/chain_of_trust.pp
+++ b/modules/scriptworker/manifests/chain_of_trust.pp
@@ -8,8 +8,9 @@ define scriptworker::chain_of_trust(
   $git_key_repo_url,
   $git_pubkey_dir,
 
-  $pubkey,
-  $privkey,
+  $gpg_pubkey,
+  $gpg_privkey,
+  $ed25519_privkey,
 
   $username,
 ) {
@@ -50,10 +51,12 @@ define scriptworker::chain_of_trust(
         notify  => Exec['rebuild_gpg_homedirs'];
     "/home/${username}/pubkey":
         mode      => '0644',
-        content   => $pubkey,
+        content   => $gpg_pubkey,
         show_diff => true;
     "/home/${username}/privkey":
-        content => $privkey;
+        content => $gpg_privkey;
+    "/home/${username}/ed25519_privkey":
+        content => $ed25519_privkey;
   }
 
   exec {

--- a/modules/scriptworker/manifests/instance.pp
+++ b/modules/scriptworker/manifests/instance.pp
@@ -109,8 +109,9 @@ define scriptworker::instance(
         git_key_repo_url => $scriptworker::instance::settings::git_key_repo_url,
         git_pubkey_dir   => $git_pubkey_dir,
 
-        pubkey           => $config::scriptworker_gpg_public_key,
-        privkey          => $config::scriptworker_gpg_private_key,
+        gpg_pubkey       => $config::scriptworker_gpg_public_key,
+        gpg_privkey      => $config::scriptworker_gpg_private_key,
+        ed25519_privkey  => $config::scriptworker_ed25519_private_key,
 
         username         => $username,
       }

--- a/modules/scriptworker/templates/scriptworker.yaml.erb
+++ b/modules/scriptworker/templates/scriptworker.yaml.erb
@@ -59,3 +59,5 @@ gpg_homedirs:
 
 scriptworker_provisioners:
     - scriptworker-prov-v1
+
+ed25519_private_key_path: /home/<%= @username %>/ed25519_privkey

--- a/modules/shipit_scriptworker/files/requirements.txt
+++ b/modules/shipit_scriptworker/files/requirements.txt
@@ -8,8 +8,7 @@ attrs==19.1.0
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+cryptography==2.6.1
 defusedxml==0.5.0
 dictdiffer==0.7.2
 frozendict==1.2
@@ -17,26 +16,28 @@ github3.py==1.3.0
 idna==2.8
 idna_ssl==1.1.0
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
-mohawk==0.3.4 # pyup: ignore
+mohawk==0.3.4  # pyup: ignore
 multidict==4.5.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pycparser==2.19
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 redo==2.0.2
 requests==2.21.0
-scriptworker==21.0.0
-shipitapi==2.0.0
+scriptworker==22.0.0
+shipitapi==2.1.0
 shipitscript==3.1.0  # puppet: nodownload
 six==1.12.0
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
+wheel==0.33.1
 yarl==1.3.0

--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -11,9 +11,8 @@ cffi==1.12.2
 chardet==3.0.4
 click==7.0
 construct==2.9.45
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
-datadog==0.26.0
+cryptography==2.6.1
+datadog==0.27.0
 decorator==4.3.2
 defusedxml==0.5.0
 dictdiffer==0.7.2
@@ -24,31 +23,32 @@ github3.py==1.3.0
 idna==2.8
 idna_ssl==1.1.0
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
 mar==3.1.0
-mohawk==0.3.4 # pyup: ignore
+mohawk==0.3.4  # pyup: ignore
 multidict==4.5.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pyasn1==0.4.5
 pycparser==2.19
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 python-jose==3.0.1
 requests==2.21.0
 requests-hawk==1.0.0
 rsa==4.0
-scriptworker==21.0.0
+scriptworker==22.0.0
 signingscript==9.6.0  # puppet: nodownload
 signtool==3.2.1
-simplejson==3.16.0  # pyup: ignore
 six==1.12.0
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
+wheel==0.33.1
 yarl==1.3.0

--- a/modules/transparency_scriptworker/files/requirements.txt
+++ b/modules/transparency_scriptworker/files/requirements.txt
@@ -8,8 +8,7 @@ attrs==19.1.0
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+cryptography==2.6.1
 defusedxml==0.5.0
 dictdiffer==0.7.2
 frozendict==1.2
@@ -17,25 +16,27 @@ github3.py==1.3.0
 idna==2.8
 idna_ssl==1.1.0
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
 mohawk==0.3.4 # pyup: ignore
 multidict==4.5.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pycparser==2.19
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 redo==2.0.2
 requests==2.21.0
-scriptworker==21.0.0
+scriptworker==22.0.0
 six==1.12.0
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 transparencyscript==0.0.4  # puppet: nodownload
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
+wheel==0.33.1
 yarl==1.3.0

--- a/modules/tree_scriptworker/files/requirements.txt
+++ b/modules/tree_scriptworker/files/requirements.txt
@@ -8,8 +8,7 @@ attrs==19.1.0
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
-# Bug 1507497 - Cryptography unable to update past 2.3.x on scriptworkers
-cryptography==2.3.1  # pyup: ignore
+cryptography==2.6.1
 defusedxml==0.5.0
 dictdiffer==0.7.2
 frozendict==1.2
@@ -17,24 +16,26 @@ github3.py==1.3.0
 idna==2.8
 idna_ssl==1.1.0
 json-e==3.0.0
-jsonschema==2.6.0 # pyup: ignore
+jsonschema==3.0.1
 jwcrypto==0.6.0
-mohawk==0.3.4 # pyup: ignore
+mohawk==0.3.4  # pyup: ignore
 multidict==4.5.2
 pexpect==4.6.0
 ptyprocess==0.6.0
 pycparser==2.19
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 requests==2.21.0
-scriptworker==21.0.0
+scriptworker==22.0.0
 six==1.12.0
 slugid==1.0.7 # pyup: ignore
 taskcluster==6.0.0
-taskcluster-urls==10.1.0 # pyup: ignore
+taskcluster-urls==11.0.0
 treescript==1.1.3  # puppet: nodownload
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
+wheel==0.33.1
 yarl==1.3.0


### PR DESCRIPTION
We probably have to deal with https://github.com/mozilla-releng/pushsnapscript/pull/18 before we can roll this out.