### PR TITLE
Telegraf on hw workers

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -292,6 +292,12 @@ class config inherits config::base {
 
     $buildmaster_ssh_keys              = [ 'ffxbld_rsa', 'tbirdbld_dsa', 'trybld_dsa' ]
 
+    # monitoring
+    $telegraf_host                     = 'https://telegraf.relops.mozops.net'
+    $telegraf_db                       = 'relops'
+    $telegraf_user                     = 'relops_wo'
+    $telegraf_password                 = secret('relops_influx_wo_password')
+
     case $::fqdn {
         /.*\.(mdc1|use1|usw2)\.mozilla\.com/: {
                 $collectd_write = {

--- a/modules/config/manifests/base.pp
+++ b/modules/config/manifests/base.pp
@@ -132,6 +132,12 @@ class config::base {
     # a comma-separated list of hosts which can connect to the NRPE daemon
     $nrpe_allowed_hosts     = '127.0.0.1'
 
+    # influxdb_host for telegraf monitoring output
+    $telegraf_host          = undef
+    $telegraf_db            = undef
+    $telegraf_user          = undef
+    $telegraf_password      = undef
+
     # a hash of collectd write modules and there configurations.
     # If undef, module is disabled
     $collectd_write         = undef

--- a/modules/packages/manifests/setup.pp
+++ b/modules/packages/manifests/setup.pp
@@ -237,7 +237,7 @@ class packages::setup {
             }
             # to flush the package index, increase this value by one (or
             # anything, really, just change it).
-            $repoflag = 47
+            $repoflag = 48
             file {
                 '/etc/.repo-flag':
                     content =>
@@ -389,6 +389,11 @@ class packages::setup {
                     gpg_key      => 'puppet:///modules/packages/0EBFCD88.txt';
                 'nrpe':
                     url_path     => 'repos/apt/custom/nrpe',
+                    distribution => $::lsbdistcodename,
+                    options      => ['trusted=yes'],
+                    components   => ['all'];
+                'telegraf':
+                    url_path     => 'repos/apt/custom/telegraf',
                     distribution => $::lsbdistcodename,
                     options      => ['trusted=yes'],
                     components   => ['all'];

--- a/modules/packages/manifests/telegraf-dmg.sh
+++ b/modules/packages/manifests/telegraf-dmg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=${1:-1.9.3}
+version=${1:-1.10.2}
 url=${2:-https://homebrew.bintray.com/bottles/telegraf-${version}.mojave.bottle.tar.gz}
 fullname=telegraf-$version
 

--- a/modules/packages/manifests/telegraf-dmg.sh
+++ b/modules/packages/manifests/telegraf-dmg.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+version=${1:-1.9.3}
+url=${2:-https://homebrew.bintray.com/bottles/telegraf-${version}.mojave.bottle.tar.gz}
+fullname=telegraf-$version
+
+curl -L -o ${fullname}.tgz $url
+
+confpath=pkgroot/etc/telegraf/telegraf.d
+mkdir -p $confpath
+
+binpath=pkgroot/usr/local/bin
+mkdir -p $binpath
+tar -xvzf ${fullname}.tgz --strip-components=3 -C $binpath */*/bin/telegraf
+
+mkdir -p pkgroot/Library/LaunchDaemons
+cat << EOF > pkgroot/Library/LaunchDaemons/com.influxdb.telegraf.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+    <key>Label</key>
+    <string>com.influxdb.telegraf</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/bin/telegraf</string>
+      <string>-config</string>
+      <string>/etc/telegraf/telegraf.conf</string>
+      <string>-config-directory</string>
+      <string>/etc/telegraf/telegraf.d</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>/var</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/telegraf.log</string>
+    <key>StandardOutPath</key>
+    <string>/var/log/telegraf.log</string>
+  </dict>
+</plist>
+EOF
+
+mkdir dmg
+pkgbuild --root pkgroot -i com.influxdb.telegraf --install-location / dmg/${fullname}.pkg
+
+hdiutil makehybrid -ov -hfs -hfs-volume-name $fullname -o ./$fullname.dmg dmg
+echo DMG is at $PWD/$fullname.dmg
+
+

--- a/modules/packages/manifests/telegraf.pp
+++ b/modules/packages/manifests/telegraf.pp
@@ -17,7 +17,7 @@ class packages::telegraf {
                    Anchor['packages::telegraf::begin'] ->
                    package {
                        'telegraf':
-                           ensure => '1.10.2';
+                           ensure => '1.10.2-1';
                            #    install_options => [ '--no-install-recommends' ];
                    } -> Anchor['packages::telegraf::end']
                 }

--- a/modules/packages/manifests/telegraf.pp
+++ b/modules/packages/manifests/telegraf.pp
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::telegraf {
+
+    anchor {
+        'packages::telegraf::begin': ;
+        'packages::telegraf::end': ;
+    }
+
+    case $::operatingsystem {
+        Ubuntu: {
+            case $::operatingsystemrelease {
+                16.04:  {
+                    realize(Packages::Aptrepo['telegraf'])
+                   Anchor['packages::telegraf::begin'] ->
+                   package {
+                       'telegraf':
+                           ensure => 'latest';
+                           #    install_options => [ '--no-install-recommends' ];
+                   } -> Anchor['packages::telegraf::end']
+                }
+                default: {
+                    fail("Ubuntu ${::operatingsystemrelease} is not supported")
+                }
+            }
+        }
+        Darwin: {
+            packages::pkgdmg {
+                'telegraf':
+                    version             => '1.9.3',
+                    os_version_specific => false,
+                    private             => false;
+            }
+        }
+        default: {
+            fail("Cannot install on ${::operatingsystem}")
+        }
+    }
+}

--- a/modules/packages/manifests/telegraf.pp
+++ b/modules/packages/manifests/telegraf.pp
@@ -17,7 +17,7 @@ class packages::telegraf {
                    Anchor['packages::telegraf::begin'] ->
                    package {
                        'telegraf':
-                           ensure => 'latest';
+                           ensure => '1.10.2';
                            #    install_options => [ '--no-install-recommends' ];
                    } -> Anchor['packages::telegraf::end']
                 }
@@ -29,7 +29,7 @@ class packages::telegraf {
         Darwin: {
             packages::pkgdmg {
                 'telegraf':
-                    version             => '1.9.3',
+                    version             => '1.10.2',
                     os_version_specific => false,
                     private             => false;
             }

--- a/modules/packages/manifests/telegraf.pp
+++ b/modules/packages/manifests/telegraf.pp
@@ -14,12 +14,12 @@ class packages::telegraf {
             case $::operatingsystemrelease {
                 16.04:  {
                     realize(Packages::Aptrepo['telegraf'])
-                   Anchor['packages::telegraf::begin'] ->
-                   package {
-                       'telegraf':
-                           ensure => '1.10.2-1';
-                           #    install_options => [ '--no-install-recommends' ];
-                   } -> Anchor['packages::telegraf::end']
+                    Anchor['packages::telegraf::begin'] ->
+                    package {
+                        'telegraf':
+                            ensure => '1.10.2-1';
+                            #    install_options => [ '--no-install-recommends' ];
+                    } -> Anchor['packages::telegraf::end']
                 }
                 default: {
                     fail("Ubuntu ${::operatingsystemrelease} is not supported")

--- a/modules/telegraf/manifests/config.pp
+++ b/modules/telegraf/manifests/config.pp
@@ -5,15 +5,6 @@
 class telegraf::config inherits telegraf {
 
   file {
-    $::telegraf::config_file:
-      ensure  => file,
-      content => template('telegraf/telegraf.conf.erb'),
-      owner   => $::telegraf::config_file_owner,
-      group   => $::telegraf::config_file_group,
-      mode    => '0640',
-      notify  => Class['::telegraf::service'],
-      require => Class['::telegraf::install'],
-    ;
     $::telegraf::config_folder:
       ensure  => directory,
       owner   => $::telegraf::config_file_owner,
@@ -21,6 +12,15 @@ class telegraf::config inherits telegraf {
       mode    => '0770',
       purge   => $::telegraf::purge_config_fragments,
       recurse => true,
+      notify  => Class['::telegraf::service'],
+      require => Class['::telegraf::install'],
+    ;
+    $::telegraf::config_file:
+      ensure  => file,
+      content => template('telegraf/telegraf.conf.erb'),
+      owner   => $::telegraf::config_file_owner,
+      group   => $::telegraf::config_file_group,
+      mode    => '0640',
       notify  => Class['::telegraf::service'],
       require => Class['::telegraf::install'],
     ;

--- a/modules/telegraf/manifests/install.pp
+++ b/modules/telegraf/manifests/install.pp
@@ -9,19 +9,6 @@ class telegraf::install {
 
   if $::telegraf::manage_repo {
     case $::osfamily {
-      'Debian': {
-        apt::source { 'influxdata':
-          comment  => 'Mirror for InfluxData packages',
-          location => "https://repos.influxdata.com/${_operatingsystem}",
-          release  => $::lsbdistcodename,
-          repos    => $::telegraf::repo_type,
-          key      => {
-            'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
-            'source' => 'https://repos.influxdata.com/influxdb.key',
-          },
-        }
-        Class['apt::update'] -> Package[$::telegraf::package_name]
-      }
       'RedHat': {
         yumrepo { 'influxdata':
           name     => 'influxdata',
@@ -37,7 +24,7 @@ class telegraf::install {
         # repo is not applicable to windows
       }
       default: {
-        fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu and Windows are supported at this time')
+        # repo is only being used for RedHat/CentOS
       }
     }
   }
@@ -53,6 +40,9 @@ class telegraf::install {
       source          => $::telegraf::windows_package_url,
       install_options => $::telegraf::install_options,
     }
+  } elsif $::osfamily != 'RedHat' {
+    require packages::telegraf
+    require users::telegraf
   } else {
     ensure_packages([$::telegraf::package_name])
   }

--- a/modules/telegraf/manifests/service.pp
+++ b/modules/telegraf/manifests/service.pp
@@ -18,13 +18,13 @@ class telegraf::service {
 
   if $::telegraf::manage_service {
     service { 'telegraf':
-      name      => $service_name,
       ensure    => $telegraf::service_ensure,
       hasstatus => $telegraf::service_hasstatus,
       enable    => $telegraf::service_enable,
       restart   => $telegraf::service_restart,
       require   => Class['::telegraf::config'],
       provider  => $service_provider,
+      name      => $service_name,
     }
   }
 }

--- a/modules/telegraf/manifests/service.pp
+++ b/modules/telegraf/manifests/service.pp
@@ -4,13 +4,27 @@
 #
 class telegraf::service {
 
+  case $::operatingsystem {
+    'Ubuntu' : {
+      $service_provider = 'systemd'
+    }
+    'Darwin' : {
+      $service_name = 'com.influxdb.telegraf'
+    }
+    default : {
+      $service_provider = undef
+    }
+  }
+
   if $::telegraf::manage_service {
     service { 'telegraf':
+      name      => $service_name,
       ensure    => $telegraf::service_ensure,
       hasstatus => $telegraf::service_hasstatus,
       enable    => $telegraf::service_enable,
       restart   => $telegraf::service_restart,
       require   => Class['::telegraf::config'],
+      provider  => $service_provider,
     }
   }
 }

--- a/modules/toplevel/manifests/worker.pp
+++ b/modules/toplevel/manifests/worker.pp
@@ -5,14 +5,75 @@
 # All TaskCluster workers are subclasses of this class.
 
 class toplevel::worker inherits toplevel::base {
+    include ::config
+    include ::generic_worker
     include disableservices::slave
     include puppet::atboot
     include sudoers::reboot
     include users::builder
     include python::system_pip_conf
+
     if ($::operatingsystem == 'Darwin') or ($::operatingsystem == 'Ubuntu') {
         # roller user ssh
         include users::roller
+    }
+
+    $group = $::operatingsystem ? {
+        Darwin  => 'staff',
+        default => undef,
+    }
+
+    class { 'telegraf':
+        interval       => '60s',
+        flush_interval => '600s',
+        hostname => regsubst($::fqdn, '([^\.]+)\..*', '\1'),
+        config_file_group => $group,
+
+        global_tags    => {
+            'fqdn'        => $::fqdn,
+            'workerType'  => $generic_worker::worker_type,
+            'workerGroup' => $generic_worker::worker_group,
+            'dataCenter'  => regsubst($::fqdn, '.*\.releng\.(.+)\.mozilla\..*', '\1'),
+        },
+        outputs        => {
+            'influxdb' => {
+                'urls'     => [ $::config::telegraf_host ],
+                'database' => $::config::telegraf_db,
+                'username' => $::config::telegraf_user,
+                'password' => $::config::telegraf_password,
+                'skip_database_creation' => true,
+            }
+        },
+        inputs => {
+        },
+    }
+
+    telegraf::input { 'puppet-agent':
+        plugin_type => 'puppetagent',
+    }
+
+    telegraf::input { 'procstat':
+        plugin_type => 'procstat',
+        options => {
+          'exe' => 'generic-worker',
+        },
+    }
+
+    telegraf::input { 'logparser':
+        plugin_type => 'logparser',
+        options => {
+          'files' => [ '~cltbld/tasks/task*/logs/*error.log' ],
+          'from_beginning' => false,
+        },
+        single_section => {
+          'logparser.grok' => {
+            'timezone' => 'Local',
+            'patterns' => [ '%{TIME}%{SPACE}%{LOGLEVEL} - The %{NOTSPACE:group:tag} suite: %{NOTSPACE:name:tag} %{GREEDYDATA:message}',
+                            '%{TIME}%{SPACE}%{LOGLEVEL} - %{NOTSPACE:exception:tag}E[roxceptin]*: %{GREEDYDATA:message}',
+                            '\[([^:]*): %{TIMESTAMP_ISO8601:timestamp:ts-"2006-01-02 15:04:05.000000Z07:00"}\] %{WORD:state} %{GREEDYDATA:step} step(\.| \(%{WORD:result}\))',
+            ]
+          },
+        },
     }
 
     # validate apple firmware versions

--- a/modules/toplevel/manifests/worker.pp
+++ b/modules/toplevel/manifests/worker.pp
@@ -24,27 +24,27 @@ class toplevel::worker inherits toplevel::base {
     }
 
     class { 'telegraf':
-        interval       => '60s',
-        flush_interval => '600s',
-        hostname => regsubst($::fqdn, '([^\.]+)\..*', '\1'),
+        interval          => '60s',
+        flush_interval    => '600s',
+        hostname          => regsubst($::fqdn, '([^\.]+)\..*', '\1'),
         config_file_group => $group,
 
-        global_tags    => {
+        global_tags       => {
             'fqdn'        => $::fqdn,
             'workerType'  => $generic_worker::worker_type,
             'workerGroup' => $generic_worker::worker_group,
             'dataCenter'  => regsubst($::fqdn, '.*\.releng\.(.+)\.mozilla\..*', '\1'),
         },
-        outputs        => {
-            'influxdb' => {
-                'urls'     => [ $::config::telegraf_host ],
-                'database' => $::config::telegraf_db,
-                'username' => $::config::telegraf_user,
-                'password' => $::config::telegraf_password,
+        outputs           => {
+            'influxdb'    => {
+                'urls'                   => [ $::config::telegraf_host ],
+                'database'               => $::config::telegraf_db,
+                'username'               => $::config::telegraf_user,
+                'password'               => $::config::telegraf_password,
                 'skip_database_creation' => true,
             }
         },
-        inputs => {
+        inputs            => {
         },
     }
 
@@ -54,15 +54,15 @@ class toplevel::worker inherits toplevel::base {
 
     telegraf::input { 'procstat':
         plugin_type => 'procstat',
-        options => {
-          'exe' => 'generic-worker',
+        options     => {
+          'exe'     => 'generic-worker',
         },
     }
 
     telegraf::input { 'logparser':
-        plugin_type => 'logparser',
-        options => {
-          'files' => [ '~cltbld/tasks/task*/logs/*error.log' ],
+        plugin_type    => 'logparser',
+        options        => {
+          'files'          => [ '~cltbld/tasks/task*/logs/*error.log' ],
           'from_beginning' => false,
         },
         single_section => {

--- a/modules/users/manifests/telegraf.pp
+++ b/modules/users/manifests/telegraf.pp
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class users::telegraf {
+    $username = 'telegraf'
+    $home = $::operatingsystem ? {
+        Darwin  => "/Users/${username}",
+        default => "/home/${username}"
+    }
+    $group = $::operatingsystem ? {
+        Darwin  => 'staff',
+        Ubuntu  => undef,
+        default => $username
+    }
+
+    user {
+        'telegraf':
+            # password   => '*',  # none allowed
+            groups     => $group,
+            comment    => 'metrics collection';
+    }
+}

--- a/modules/users/manifests/telegraf.pp
+++ b/modules/users/manifests/telegraf.pp
@@ -17,7 +17,7 @@ class users::telegraf {
     user {
         'telegraf':
             # password   => '*',  # none allowed
-            groups     => $group,
-            comment    => 'metrics collection';
+            groups  => $group,
+            comment => 'metrics collection';
     }
 }

--- a/modules/users/manifests/telegraf.pp
+++ b/modules/users/manifests/telegraf.pp
@@ -15,9 +15,10 @@ class users::telegraf {
     }
 
     user {
-        'telegraf':
+        $username:
             # password   => '*',  # none allowed
-            groups  => $group,
+            gid     => $group,
+            home    => $home,
             comment => 'metrics collection';
     }
 }


### PR DESCRIPTION
Adding the telegraf daemon to the hardware workers.
1. adds telegraf config into toplevel/worker
2. updates telegraf module for MacOS install and service control
3. adds a separate user for telegraf to run under
4. includes the build script for the MacOS dmg