### PR TITLE
Updates mozapkpublisher to 2.0.2

### DIFF
--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -41,7 +41,7 @@ kiwisolver==1.0.1
 lxml==4.3.3
 matplotlib==3.0.3
 mohawk==0.3.4  # pyup: ignore
-mozapkpublisher==2.0.1
+mozapkpublisher==2.0.2
 mozilla-version==0.3.1
 multidict==4.5.2
 networkx==2.3


### PR DESCRIPTION
This should allow Focus builds to be published again