### PR TITLE
Use simple quotes instead of double quotes in /nrpe/manifests/base.pp

### DIFF
--- a/modules/nrpe/manifests/base.pp
+++ b/modules/nrpe/manifests/base.pp
@@ -50,7 +50,7 @@ class nrpe::base {
 
             if $::operatingsystem == 'CentOS' {
                 exec { 'change pid file path':
-                    command => "sed -i 's/PID_FILE=\/var\/run\/nrpe\/nrpe.pid/PID_FILE=\/var\/run\/nrpe.pid/g' /etc/init.d/nrpe",
+                    command => 'sed -i 's/PID_FILE=\/var\/run\/nrpe\/nrpe.pid/PID_FILE=\/var\/run\/nrpe.pid/g' /etc/init.d/nrpe',
                     path    => ['/bin', '/sbin', '/usr/bin'],
                     unless  => 'test `grep -w "PID_FILE=\/var\/run\/nrpe.pid" /etc/init.d/nrpe`',
                     notify  => Class['nrpe::service'],

--- a/modules/nrpe/manifests/base.pp
+++ b/modules/nrpe/manifests/base.pp
@@ -50,7 +50,7 @@ class nrpe::base {
 
             if $::operatingsystem == 'CentOS' {
                 exec { 'change pid file path':
-                    command => 'sed -i 's/PID_FILE=\/var\/run\/nrpe\/nrpe.pid/PID_FILE=\/var\/run\/nrpe.pid/g' /etc/init.d/nrpe',
+                    command => 'sed -i \'s/PID_FILE=\/var\/run\/nrpe\/nrpe.pid/PID_FILE=\/var\/run\/nrpe.pid/g\' /etc/init.d/nrpe',
                     path    => ['/bin', '/sbin', '/usr/bin'],
                     unless  => 'test `grep -w "PID_FILE=\/var\/run\/nrpe.pid" /etc/init.d/nrpe`',
                     notify  => Class['nrpe::service'],


### PR DESCRIPTION
This is a followup patch after seeing Warning: Unrecognised escape sequence '\/' in file /home/travis/build/mozilla-releng/build-puppet/modules/nrpe/manifests/base.pp at line 53 in last travis ci build at line 506-512. This warning came up in travis ci building of #460. Talked with @JohanLorenzo in #ci irc channel about the warning and this PR should solve the issue.