### PR TITLE
Inlines $jarsigner_all_certificates

### DIFF
--- a/modules/pushapk_scriptworker/manifests/jarsigner_init.pp
+++ b/modules/pushapk_scriptworker/manifests/jarsigner_init.pp
@@ -6,6 +6,8 @@ class pushapk_scriptworker::jarsigner_init {
     include ::config
     include packages::jdk17
 
+    $root = $config::scriptworker_root
+
     File {
         ensure    => 'present',
         show_diff => false,
@@ -20,7 +22,7 @@ class pushapk_scriptworker::jarsigner_init {
 
     case $pushapk_scriptworker_env {
         'dep': {
-            $dep = $pushapk_scriptworker::settings::jarsigner_all_certificates['dep']
+            $dep = "${root}/dep.cer"
             file {
                 $dep:
                     source => 'puppet:///modules/pushapk_scriptworker/dep.pem';
@@ -32,8 +34,8 @@ class pushapk_scriptworker::jarsigner_init {
             }
         }
         'prod': {
-            $nightly = $pushapk_scriptworker::settings::jarsigner_all_certificates['nightly']
-            $release = $pushapk_scriptworker::settings::jarsigner_all_certificates['release']
+            $nightly = "${root}/nightly.cer"
+            $release = "${root}/release.cer"
 
             file {
                 $nightly:
@@ -52,9 +54,9 @@ class pushapk_scriptworker::jarsigner_init {
             }
         }
         'mobile-dep': {
-            $fenix = $pushapk_scriptworker::settings::jarsigner_all_certificates['fenix-dep']
-            $focus = $pushapk_scriptworker::settings::jarsigner_all_certificates['focus-dep']
-            $reference_browser = $pushapk_scriptworker::settings::jarsigner_all_certificates['reference-browser-dep']
+            $fenix = "${root}/fenix_dep.cer"
+            $focus = "${root}/focus_dep.cer"
+            $reference_browser = "${root}/reference_browser_dep.cer"
 
             file {
                 $fenix:
@@ -76,12 +78,12 @@ class pushapk_scriptworker::jarsigner_init {
         }
         'mobile-prod': {
             # deprecated, use $fenix_nightly instead
-            $fenix = $pushapk_scriptworker::settings::jarsigner_all_certificates['fenix-release']
+            $fenix = "${root}/fenix_rel.cer"
 
-            $fenix_nightly = $pushapk_scriptworker::settings::jarsigner_all_certificates['fenix-nightly']
-            $fenix_beta = $pushapk_scriptworker::settings::jarsigner_all_certificates['fenix-beta']
-            $focus = $pushapk_scriptworker::settings::jarsigner_all_certificates['focus-release']
-            $reference_browser = $pushapk_scriptworker::settings::jarsigner_all_certificates['reference-browser-release']
+            $fenix_nightly = "${root}/fenix_nightly.cer"
+            $fenix_beta = "${root}/fenix_beta.cer"
+            $focus = "${root}/focus_release.cer"
+            $reference_browser = "${root}/reference_browser_release.cer"
 
             file {
                 $fenix:
@@ -100,8 +102,6 @@ class pushapk_scriptworker::jarsigner_init {
                 # deprecated, use "fenix-nightly" instead
                 'fenix':
                     certificate => $fenix;
-
-
                 'fenix-nightly':
                     certificate => $fenix_nightly;
                 'fenix-beta':

--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -335,19 +335,6 @@ class pushapk_scriptworker::settings {
     $jarsigner_keystore                  = "${root}/mozilla-android-keystore"
     $jarsigner_keystore_password         = secret('pushapk_scriptworker_jarsigner_keystore_password')
 
-    $jarsigner_all_certificates = {
-        'nightly'                   => "${root}/nightly.cer",
-        'release'                   => "${root}/release.cer",
-        'dep'                       => "${root}/dep.cer",
-        'fenix-dep'                 => "${root}/fenix_dep.cer",
-        'fenix-release'             => "${root}/fenix_rel.cer", # deprecated, use "fenix-nightly" instead
-        'fenix-nightly'             => "${root}/fenix_nightly.cer",
-        'fenix-beta'                => "${root}/fenix_beta.cer",
-        'focus-release'             => "${root}/focus_release.cer",
-        'reference-browser-dep'     => "${root}/reference_browser_dep.cer",
-        'reference-browser-release' => "${root}/reference_browser_release.cer",
-    }
-
     $verbose_logging                     = $_env_config['verbose_logging']
 
     $script_config                       = "${root}/script_config.json"


### PR DESCRIPTION
I'm debugging [this failure](https://tools.taskcluster.net/groups/epmNm9N2S2CdmSE1kmcYcA/tasks/c9Cl2hQPT26UEx2cOZ_Gxw/runs/0/), and I was trying to grok the `pushapk` config.
Inlining these values should make them easier to interpret.