### PR TITLE
Removes Fenix from jarsigner aliases

### DIFF
--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -52,7 +52,7 @@ pexpect==4.7.0
 pickleshare==0.7.5
 prompt_toolkit==2.0.9
 ptyprocess==0.6.0
-pushapkscript==1.0.2  # puppet: nodownload
+pushapkscript==1.0.3  # puppet: nodownload
 pyasn1==0.4.5
 pyasn1-modules==0.2.5
 pycparser==2.19

--- a/modules/pushapk_scriptworker/manifests/init.pp
+++ b/modules/pushapk_scriptworker/manifests/init.pp
@@ -106,10 +106,6 @@ class pushapk_scriptworker {
         }
         'mobile-prod': {
             file {
-                # deprecated, use "fenix-nightly" instead
-                $google_play_config['fenix']['certificate_target_location']:
-                    content     => $google_play_config['fenix']['certificate'];
-
                 $google_play_config['fenix-nightly']['certificate_target_location']:
                     content     => $google_play_config['fenix-nightly']['certificate'];
                 $google_play_config['fenix-beta']['certificate_target_location']:

--- a/modules/pushapk_scriptworker/manifests/jarsigner_init.pp
+++ b/modules/pushapk_scriptworker/manifests/jarsigner_init.pp
@@ -77,17 +77,12 @@ class pushapk_scriptworker::jarsigner_init {
             }
         }
         'mobile-prod': {
-            # deprecated, use $fenix_nightly instead
-            $fenix = "${root}/fenix_rel.cer"
-
             $fenix_nightly = "${root}/fenix_nightly.cer"
             $fenix_beta = "${root}/fenix_beta.cer"
             $focus = "${root}/focus_release.cer"
             $reference_browser = "${root}/reference_browser_release.cer"
 
             file {
-                $fenix:
-                    source => 'puppet:///modules/pushapk_scriptworker/fenix_nightly.pem';
                 $fenix_nightly:
                     source => 'puppet:///modules/pushapk_scriptworker/fenix_nightly.pem';
                 $fenix_beta:
@@ -99,9 +94,6 @@ class pushapk_scriptworker::jarsigner_init {
             }
 
             java_ks {
-                # deprecated, use "fenix-nightly" instead
-                'fenix':
-                    certificate => $fenix;
                 'fenix-nightly':
                     certificate => $fenix_nightly;
                 'fenix-beta':

--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -231,13 +231,6 @@ class pushapk_scriptworker::settings {
         }
         'mobile-prod': {
             $google_play_config = {
-                # deprecated, use "fenix-nightly" instead
-                'fenix' => {
-                    service_account             => $_google_play_accounts['fenix']['service_account'],
-                    certificate                 => $_google_play_accounts['fenix']['certificate'],
-                    certificate_target_location => "${root}/fenix.p12",
-                },
-
                 'fenix-nightly' => {
                     service_account             => $_google_play_accounts['fenix-nightly']['service_account'],
                     certificate                 => $_google_play_accounts['fenix-nightly']['certificate'],
@@ -260,19 +253,6 @@ class pushapk_scriptworker::settings {
                 },
             }
             $product_config = {
-                # deprecated, use "fenix-nightly" instead
-                'fenix' => {
-                    'has_nightly_track' => true,
-                    'service_account' => $google_play_config['fenix']['service_account'],
-                    'certificate' => $google_play_config['fenix']['certificate_target_location'],
-                    'update_google_play_strings' => false,
-                    'digest_algorithm' => 'SHA-256',
-                    'expected_package_names' => ['org.mozilla.fenix'],
-                    'skip_check_multiple_locales' => true,
-                    'skip_check_same_locales' => true,
-                    'skip_checks_fennec' => true,
-                },
-
                 'fenix-nightly' => {
                     'require_track' => 'nightly',
                     'service_account' => $google_play_config['fenix-nightly']['service_account'],
@@ -321,7 +301,6 @@ class pushapk_scriptworker::settings {
                 },
             }
             $jarsigner_certificate_aliases_content = {
-                'fenix' => 'fenix',
                 'focus' => 'focus',
                 'reference-browser' => 'reference-browser'
             }


### PR DESCRIPTION
This is needed for the Fenix Beta to be pushed to the Google Play Store

Details: Allows Fenix to supply the certificate alias as a task payload, so `pushapk_scriptworker` doesn't infer it from scopes.

Bugging you Aki because Johan is away and you're a cool guy :)