### PR TITLE
Resolve fenix nightlies failing

### DIFF
--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -52,7 +52,7 @@ pexpect==4.7.0
 pickleshare==0.7.5
 prompt_toolkit==2.0.9
 ptyprocess==0.6.0
-pushapkscript==1.0.3  # puppet: nodownload
+pushapkscript==1.0.4  # puppet: nodownload
 pyasn1==0.4.5
 pyasn1-modules==0.2.5
 pycparser==2.19

--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -231,6 +231,11 @@ class pushapk_scriptworker::settings {
         }
         'mobile-prod': {
             $google_play_config = {
+                'fenix' => { # TODO replace with fenix-nightly
+                    service_account             => $_google_play_accounts['fenix-nightly']['service_account'],
+                    certificate                 => $_google_play_accounts['fenix-nightly']['certificate'],
+                    certificate_target_location => "${root}/fenix-nightly.p12",
+                },
                 'fenix-nightly' => {
                     service_account             => $_google_play_accounts['fenix-nightly']['service_account'],
                     certificate                 => $_google_play_accounts['fenix-nightly']['certificate'],
@@ -253,8 +258,21 @@ class pushapk_scriptworker::settings {
                 },
             }
             $product_config = {
+                'fenix' => { # TODO replace with fenix-nightly
+                    'require_track' => 'nightly',
+                    'has_nightly_track' => true,
+                    'service_account' => $google_play_config['fenix-nightly']['service_account'],
+                    'certificate' => $google_play_config['fenix-nightly']['certificate_target_location'],
+                    'update_google_play_strings' => false,
+                    'digest_algorithm' => 'SHA-256',
+                    'expected_package_names' => ['org.mozilla.fenix'],
+                    'skip_check_multiple_locales' => true,
+                    'skip_check_same_locales' => true,
+                    'skip_checks_fennec' => true,
+                },
                 'fenix-nightly' => {
                     'require_track' => 'nightly',
+                    'has_nightly_track' => true,
                     'service_account' => $google_play_config['fenix-nightly']['service_account'],
                     'certificate' => $google_play_config['fenix-nightly']['certificate_target_location'],
                     'update_google_play_strings' => false,
@@ -266,6 +284,7 @@ class pushapk_scriptworker::settings {
                 },
                 'fenix-beta' => {
                     'require_track' => 'beta',
+                    'has_nightly_track' => false,
                     'service_account' => $google_play_config['fenix-beta']['service_account'],
                     'certificate' => $google_play_config['fenix-beta']['certificate_target_location'],
                     'update_google_play_strings' => false,


### PR DESCRIPTION
This does three things:
* Updates `pushapkscript` so that using `certificate_alias` doesn't throw a schema-validation error
* Adds `has_nightly_track` to configs that were missing it, since it's required
* Adds a base `fenix` product config because it's inferred from scope, and we don't have separate `project:mobile:...:fenix-$channel` scopes