### PR TITLE
Removes fenix from dep jarsigner certificate aliases

### DIFF
--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -223,7 +223,6 @@ class pushapk_scriptworker::settings {
                 },
             }
             $jarsigner_certificate_aliases_content = {
-                'fenix' => 'fenix',
                 'focus' => 'focus',
                 'reference-browser' => 'reference-browser',
             }


### PR DESCRIPTION
Fenix [provides `certificate_alias` in the payload](https://taskcluster-ui.herokuapp.com/tasks/dxlTj-sVRvGjtKl35EnKAw), so it must be removed from the config, otherwise the build fails.
(this will be made obsolete by #483, but it fixes Fenix staging builds in the meantime)