### PR TITLE
Updated notification email.

### DIFF
--- a/modules/signing_server_cert_check/files/check_sign_srv_ssl_exp.sh
+++ b/modules/signing_server_cert_check/files/check_sign_srv_ssl_exp.sh
@@ -11,8 +11,8 @@ CHECKSSL=/usr/local/bin/cert_check.sh
 
 cat $CERT | awk  'split_after == 1 {n++;split_after=0}  /-----END CERTIFICATE-----/ {split_after=1}{print > "/tmp/cert" n ".pem"}'
 
-sh $CHECKSSL -c $CERT1 -x $DAYS -ab -e ciduty@mozilla.com -E root@cruncher-aws.srv.releng.usw2.mozilla.com
-sh $CHECKSSL -c $CERT2 -x $DAYS -ab -e ciduty@mozilla.com -E root@cruncher-aws.srv.releng.usw2.mozilla.com
+sh $CHECKSSL -c $CERT1 -x $DAYS -ab -e relops@mozilla.com -E root@cruncher-aws.srv.releng.usw2.mozilla.com
+sh $CHECKSSL -c $CERT2 -x $DAYS -ab -e relops@mozilla.com -E root@cruncher-aws.srv.releng.usw2.mozilla.com
 
 rm -rf $CERT $CERT1 $CERT2
 


### PR DESCRIPTION
Future notices for the signing servers certificate expiration will be sent to the Relops email.