### PR TITLE
reenable verbose for signing scriptworkers

### DIFF
--- a/modules/signing_scriptworker/manifests/settings.pp
+++ b/modules/signing_scriptworker/manifests/settings.pp
@@ -9,7 +9,7 @@ class signing_scriptworker::settings {
     $task_max_timeout   = 7200
     $task_script        = "${root}/bin/signingscript"
     $task_script_config = "${root}/script_config.json"
-    $verbose            = false
+    $verbose            = true
     $virtualenv_version = $python3::settings::python3_virtualenv_version
     $datadog_port       = 8135
     $datadog_host       = "localhost"


### PR DESCRIPTION
Previously, we turned off verbosity for both signing scriptworkers
(daemon) and signingscript (script) to avoid so much log spam from the
signing scriptworkers.

However, the former a) broke papertrail logging at all for the signing
scriptworkers, since `verbose` specifies whether scriptworker logs to
the screen, and b) broke nagios monitoring, since the claimWork call is
what keeps the logfile up to date when the daemon is idle.

This patch reverts only the scriptworker daemon part of the patch, back
to being verbose.