### PR TITLE
Revert "Support signing via autograph omni.ja bundles."

### DIFF
--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -38,7 +38,7 @@ requests==2.22.0
 requests-hawk==1.0.0
 rsa==4.0
 scriptworker==23.0.8
-signingscript==11.0.0  # puppet: nodownload
+signingscript==10.1.0  # puppet: nodownload
 signtool==4.0.1
 six==1.12.0
 slugid==2.0.0

--- a/modules/signing_scriptworker/templates/dep-passwords.json.erb
+++ b/modules/signing_scriptworker/templates/dep-passwords.json.erb
@@ -22,8 +22,7 @@
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_dep_keyid_username"]) %>", "<%= scope.function_secret(["autograph_mar_dep_keyid_password"]) %>", ["autograph_mar384", "autograph_hash_only_mar384"], "autograph"],
         ["https://autograph-external.stage.autograph.services.mozaws.net", "signingscript", "<%= scope.function_secret(["autograph_stage_mar_dep_password"]) %>", ["autograph_stage_mar384"], "autograph"],
         ["https://autograph-external.stage.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_gpg_dep_username"]) %>", "<%= scope.function_secret(["autograph_gpg_dep_password"]) %>", ["autograph_gpg"], "autograph"],
-        ["https://autograph-external.stage.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_widevine_dep_username"]) %>", "<%= scope.function_secret(["autograph_widevine_dep_password"]) %>", ["autograph_widevine"], "autograph"],
-        ["https://autograph-external.stage.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_omnija_dep_username"]) %>", "<%= scope.function_secret(["autograph_omnija_dep_password"]) %>", ["autograph_omnija"], "autograph"]
+        ["https://autograph-external.stage.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_widevine_dep_username"]) %>", "<%= scope.function_secret(["autograph_widevine_dep_password"]) %>", ["autograph_widevine"], "autograph"]
 
     ]
 }

--- a/modules/signing_scriptworker/templates/passwords.json.erb
+++ b/modules/signing_scriptworker/templates/passwords.json.erb
@@ -21,8 +21,7 @@
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_nightly_keyid_username"]) %>", "<%= scope.function_secret(["autograph_mar_nightly_keyid_password"]) %>", ["autograph_mar384", "autograph_hash_only_mar384"], "autograph"],
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_fennec_nightly_username"]) %>", "<%= scope.function_secret(["autograph_fennec_nightly_password"]) %>", ["autograph_apk_fennec_sha1"], "autograph"],
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_gpg_prod_username"]) %>", "<%= scope.function_secret(["autograph_gpg_prod_password"]) %>", ["autograph_gpg"], "autograph"],
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_widevine_prod_username"]) %>", "<%= scope.function_secret(["autograph_widevine_prod_password"]) %>", ["autograph_widevine"], "autograph"],
-        ["https://autograph-external.stage.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_omnija_prod_username"]) %>", "<%= scope.function_secret(["autograph_omnija_prod_password"]) %>", ["autograph_omnija"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_widevine_prod_username"]) %>", "<%= scope.function_secret(["autograph_widevine_prod_password"]) %>", ["autograph_widevine"], "autograph"]
     ],
     "<%= @env_config['scope_prefixes'][0] %>cert:release-signing": [
         ["signing7.srv.releng.mdc1.mozilla.com:9120", "<%= scope.function_secret(["signing_server_username"]) %>", "<%= scope.function_secret(["signing_server_release_password"]) %>", ["gpg", "sha2signcode", "sha2signcodestub", "sha2signcode-v2", "sha2signcodestub-v2", "mar", "widevine", "widevine_blessed"], "signing_server"],
@@ -46,7 +45,6 @@
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_mar_release_keyid_username"]) %>", "<%= scope.function_secret(["autograph_mar_release_keyid_password"]) %>", ["autograph_mar384", "autograph_hash_only_mar384"], "autograph"],
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_fennec_release_username"]) %>", "<%= scope.function_secret(["autograph_fennec_release_password"]) %>", ["autograph_apk_fennec_sha1"], "autograph"],
         ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_gpg_prod_username"]) %>", "<%= scope.function_secret(["autograph_gpg_prod_password"]) %>", ["autograph_gpg"], "autograph"],
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_widevine_prod_username"]) %>", "<%= scope.function_secret(["autograph_widevine_prod_password"]) %>", ["autograph_widevine"], "autograph"],
-        ["https://autograph-external.stage.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_omnija_prod_username"]) %>", "<%= scope.function_secret(["autograph_omnija_prod_password"]) %>", ["autograph_omnija"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_widevine_prod_username"]) %>", "<%= scope.function_secret(["autograph_widevine_prod_password"]) %>", ["autograph_widevine"], "autograph"]
     ]
 }


### PR DESCRIPTION
Reverts mozilla-releng/build-puppet#506

https://queue.taskcluster.net/v1/task/Aj_7jUC_RBmlNUM0eUL21Q/runs/0/artifacts/public/logs/live_backing.log

Not sure how I broke this -- I suspect the wheel isn't pulling in the right files.