### PR TITLE
Bug 1548545 - add support for gpg signing in beetmover's maven world

### DIFF
--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -364,6 +364,8 @@ node /^beetmoverworker-.*\.srv\.releng\..*\.mozilla\.com$/ {
 node /^beetmover-dev.*\.srv\.releng\..*\.mozilla\.com$/ {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'dev'
+    $pin_puppet_server = 'releng-puppet2.srv.releng.mdc1.mozilla.com'
+    $pin_puppet_env    = 'mtabara'
     $timezone            = 'UTC'
     $only_user_ssh       = true
     include toplevel::server::beetmoverscriptworker

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -421,6 +421,8 @@ node /^appsv-beetmover-\d*\.srv\.releng\..*\.mozilla\.com$/ {
 node /^appsv-beetmover-dev\d*\.srv\.releng\..*\.mozilla\.com$/ {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'appservices-dev'
+    $pin_puppet_server = 'releng-puppet2.srv.releng.mdc1.mozilla.com'
+    $pin_puppet_env    = 'mtabara'
     $timezone            = 'UTC'
     $only_user_ssh       = true
     include toplevel::server::beetmoverscriptworker

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -364,8 +364,6 @@ node /^beetmoverworker-.*\.srv\.releng\..*\.mozilla\.com$/ {
 node /^beetmover-dev.*\.srv\.releng\..*\.mozilla\.com$/ {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'dev'
-    $pin_puppet_server = 'releng-puppet2.srv.releng.mdc1.mozilla.com'
-    $pin_puppet_env    = 'mtabara'
     $timezone            = 'UTC'
     $only_user_ssh       = true
     include toplevel::server::beetmoverscriptworker
@@ -400,8 +398,6 @@ node /^mobile-beetmover-\d*\.srv\.releng\..*\.mozilla\.com$/ {
 node /^mobil-beetmover-dev\d*\.srv\.releng\..*\.mozilla\.com$/ {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'mobile-dev'
-    $pin_puppet_server = 'releng-puppet2.srv.releng.mdc1.mozilla.com'
-    $pin_puppet_env    = 'mtabara'
     $timezone            = 'UTC'
     $only_user_ssh       = true
     include toplevel::server::beetmoverscriptworker
@@ -421,8 +417,6 @@ node /^appsv-beetmover-\d*\.srv\.releng\..*\.mozilla\.com$/ {
 node /^appsv-beetmover-dev\d*\.srv\.releng\..*\.mozilla\.com$/ {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'appservices-dev'
-    $pin_puppet_server = 'releng-puppet2.srv.releng.mdc1.mozilla.com'
-    $pin_puppet_env    = 'mtabara'
     $timezone            = 'UTC'
     $only_user_ssh       = true
     include toplevel::server::beetmoverscriptworker

--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -398,6 +398,8 @@ node /^mobile-beetmover-\d*\.srv\.releng\..*\.mozilla\.com$/ {
 node /^mobil-beetmover-dev\d*\.srv\.releng\..*\.mozilla\.com$/ {
     $aspects             = [ 'maximum-security' ]
     $beetmoverworker_env = 'mobile-dev'
+    $pin_puppet_server = 'releng-puppet2.srv.releng.mdc1.mozilla.com'
+    $pin_puppet_env    = 'mtabara'
     $timezone            = 'UTC'
     $only_user_ssh       = true
     include toplevel::server::beetmoverscriptworker

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -7,7 +7,7 @@ arrow==0.14.2
 asn1crypto==0.24.0
 async_timeout==3.0.1
 attrs==19.1.0
-beetmoverscript==8.5.0  # puppet: nodownload
+beetmoverscript==8.5.1.dev0  # puppet: nodownload
 boto3==1.9.176
 botocore==1.12.176
 certifi==2019.6.16

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -7,7 +7,7 @@ arrow==0.14.2
 asn1crypto==0.24.0
 async_timeout==3.0.1
 attrs==19.1.0
-beetmoverscript==8.5.1.dev0  # puppet: nodownload
+beetmoverscript==8.5.1  # puppet: nodownload
 boto3==1.9.176
 botocore==1.12.176
 certifi==2019.6.16

--- a/modules/signing_scriptworker/manifests/settings.pp
+++ b/modules/signing_scriptworker/manifests/settings.pp
@@ -114,7 +114,7 @@ class signing_scriptworker::settings {
             taskcluster_client_id    => 'project/mobile/focus/releng/scriptworker/signing/production',
             taskcluster_access_token => secret('mobile_focus_signing_scriptworker_taskcluster_access_token'),
             passwords_template       => 'passwords-mobile.json.erb',
-            scope_prefixes           => ['project:mobile:focus:releng:signing:', 'project:mobile:fenix:releng:signing:', 'project:mobile:reference-browser:releng:signing:'],
+            scope_prefixes           => ['project:mobile:focus:releng:signing:', 'project:mobile:android-components:releng:signing:', 'project:mobile:fenix:releng:signing:', 'project:mobile:reference-browser:releng:signing:'],
             sign_chain_of_trust      => true,
             verify_chain_of_trust    => true,
             verify_cot_signature     => true,

--- a/modules/signing_scriptworker/manifests/settings.pp
+++ b/modules/signing_scriptworker/manifests/settings.pp
@@ -99,7 +99,7 @@ class signing_scriptworker::settings {
             taskcluster_client_id    => 'project/mobile/focus/releng/scriptworker/signing/dep',
             taskcluster_access_token => secret('mobile_focus_signing_dep_scriptworker_taskcluster_access_token'),
             passwords_template       => 'dep-passwords-mobile.json.erb',
-            scope_prefixes           => ['project:mobile:focus:releng:signing:', 'project:mobile:fenix:releng:signing:', 'project:mobile:reference-browser:releng:signing:'],
+            scope_prefixes           => ['project:mobile:focus:releng:signing:', 'project:mobile:android-components:releng:signing:', 'project:mobile:fenix:releng:signing:', 'project:mobile:reference-browser:releng:signing:'],
             sign_chain_of_trust      => false,
             verify_chain_of_trust    => true,
             verify_cot_signature     => false,

--- a/modules/signing_scriptworker/templates/dep-passwords-mobile.json.erb
+++ b/modules/signing_scriptworker/templates/dep-passwords-mobile.json.erb
@@ -7,5 +7,8 @@
     ],
     "project:mobile:reference-browser:releng:signing:cert:dep-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_geckoview_reference_browser_dep", "<%= scope.function_secret(["autograph_reference_browser_dep_password"]) %>", ["autograph_apk_reference_browser"], "autograph"]
+    ],
+    "project:mobile:android-components:releng:signing:": [
+        ["https://autograph-external.stage.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_gpg_dep_username"]) %>", "<%= scope.function_secret(["autograph_gpg_dep_password"]) %>", ["autograph_gpg"], "autograph"]
     ]
 }

--- a/modules/signing_scriptworker/templates/dep-passwords-mobile.json.erb
+++ b/modules/signing_scriptworker/templates/dep-passwords-mobile.json.erb
@@ -8,7 +8,7 @@
     "project:mobile:reference-browser:releng:signing:cert:dep-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_geckoview_reference_browser_dep", "<%= scope.function_secret(["autograph_reference_browser_dep_password"]) %>", ["autograph_apk_reference_browser"], "autograph"]
     ],
-    "project:mobile:android-components:releng:signing:": [
+    "project:mobile:android-components:releng:signing:cert:dep-signing": [
         ["https://autograph-external.stage.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_gpg_dep_username"]) %>", "<%= scope.function_secret(["autograph_gpg_dep_password"]) %>", ["autograph_gpg"], "autograph"]
     ]
 }

--- a/modules/signing_scriptworker/templates/passwords-mobile.json.erb
+++ b/modules/signing_scriptworker/templates/passwords-mobile.json.erb
@@ -13,5 +13,8 @@
     ],
     "project:mobile:reference-browser:releng:signing:cert:release-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_geckoview_reference_browser_rel", "<%= scope.function_secret(["autograph_reference_browser_prod_password"]) %>", ["autograph_apk_reference_browser"], "autograph"]
+    ],
+    "project:mobile:android-components:releng:signing:cert:release-signing": [
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "<%= scope.function_secret(["autograph_gpg_prod_username"]) %>", "<%= scope.function_secret(["autograph_gpg_prod_password"]) %>", ["autograph_gpg"], "autograph"]
     ]
 }


### PR DESCRIPTION
Blocked on https://github.com/mozilla-releng/beetmoverscript/pull/226 roll-out to puppet Pypi.