### PR TITLE
Signs fenix production/nightly with correct, unswapped key

### DIFF
--- a/modules/signing_scriptworker/templates/passwords-mobile.json.erb
+++ b/modules/signing_scriptworker/templates/passwords-mobile.json.erb
@@ -2,15 +2,14 @@
     "project:mobile:focus:releng:signing:cert:release-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_focus", "<%= scope.function_secret(["autograph_focus_prod_password"]) %>", ["autograph_focus"], "autograph"]
     ],
-    <%# Fenix nightly and production key names are reversed: https://bugzilla.mozilla.org/show_bug.cgi?id=1556428 %>
     "project:mobile:fenix:releng:signing:cert:nightly-signing": [
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_fenix_release", "<%= scope.function_secret(["autograph_fenix_production_password"]) %>", ["autograph_apk"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_fenix_nightly", "<%= scope.function_secret(["autograph_fenix_nightly_password"]) %>", ["autograph_apk"], "autograph"]
     ],
     "project:mobile:fenix:releng:signing:cert:beta-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_fenix_beta", "<%= scope.function_secret(["autograph_fenix_beta_password"]) %>", ["autograph_apk"], "autograph"]
     ],
     "project:mobile:fenix:releng:signing:cert:production-signing": [
-        ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_fenix_nightly", "<%= scope.function_secret(["autograph_fenix_nightly_password"]) %>", ["autograph_apk"], "autograph"]
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_fenix_release", "<%= scope.function_secret(["autograph_fenix_production_password"]) %>", ["autograph_apk"], "autograph"]
     ],
     "project:mobile:reference-browser:releng:signing:cert:release-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_geckoview_reference_browser_rel", "<%= scope.function_secret(["autograph_reference_browser_prod_password"]) %>", ["autograph_apk_reference_browser"], "autograph"]


### PR DESCRIPTION
When [bug 1556428](https://bugzilla.mozilla.org/show_bug.cgi?id=1556428) lands, merge this PR.