### PR TITLE
Temporarily re-allow VNC on mac-v2-signing

### DIFF
--- a/modules/fw/manifests/profiles/mac_signing.pp
+++ b/modules/fw/manifests/profiles/mac_signing.pp
@@ -6,6 +6,7 @@ class fw::profiles::mac_signing {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::roles::vnc_from_rejh_logging
             include ::fw::roles::ssh_from_rejh_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::dep_signing_from_osx


### PR DESCRIPTION
I'd like to generate the another cert for pkg signing and need to use the Keychain via VNC to do so.