### PR TITLE
bug 1561040 remove graphite write

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -298,27 +298,6 @@ class config inherits config::base {
     $telegraf_user                     = 'relops_wo'
     $telegraf_password                 = secret('relops_influx_wo_password')
 
-    case $::fqdn {
-        /.*\.(mdc1|use1|usw2)\.mozilla\.com/: {
-                $collectd_write = {
-                    graphite_nodes => {
-                        'graphite1.private.mdc1.mozilla.com' => {
-                            'port' => '2003', 'prefix' => 'hosts.',
-                        },
-                    },
-                }
-        }
-        /.*\.mdc2\.mozilla\.com/: {
-                $collectd_write = {
-                    graphite_nodes => {
-                        'graphite1.private.mdc2.mozilla.com' => {
-                            'port' => '2003', 'prefix' => 'hosts.',
-                        },
-                    },
-                }
-        }
-    }
-
     #### start configuration information for rsyslog logging
 
     # cef server for auditd output


### PR DESCRIPTION
IT will turn off the graphite hosts since everyone is moving to other metrics collection.

remove setting of collectd_write in moco_config:
1. the graphite module uses this config variable as an on/off switch
2. metcollect (windows) module also turns on/off using this variable (but windows is not using build-puppet, right?)