### PR TITLE
Adds remaining fenix channels to pushapk dep config

### DIFF
--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -157,7 +157,7 @@ class pushapk_scriptworker::settings {
                     'skip_checks_fennec' => true,
                     'map_channels_to_tracks' => true,
                     'single_app_config' => {
-                        'package_names' => ['org.mozilla.fenix'],
+                        'package_names' => ['org.mozilla.fenix', 'org.mozilla.fenix.beta', 'org.mozilla.fenix.nightly'],
                         'service_account' => 'dummy',
                         'google_credentials_file' => "${root}/fenix.p12",
                         'certificate_alias' => 'fenix',


### PR DESCRIPTION
The current `fenix` staging config only supports `org.mozilla.fenix`, which means that staging beta and nightly builds fail