### PR TITLE
fix docutils

### DIFF
--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -16,7 +16,7 @@ chardet==3.0.4
 click==7.0
 cryptography==2.7
 dictdiffer==0.8.0
-docutils==0.15.1
+docutils==0.15.1.post1
 frozendict==1.2
 github3.py==1.3.0
 idna==2.8


### PR DESCRIPTION
https://pypi.org/project/docutils/#files

We're getting puppet mail about this. I was able to download docutils-0.15.1.post1 and that fixed a manual install, but we need to land this change to stop getting puppet errors.