### PR TITLE
avoid puppet download docutils emails

### DIFF
--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -9,7 +9,7 @@ async_timeout==3.0.1
 attrs==19.1.0
 beetmoverscript==8.5.3  # puppet: nodownload
 boto3==1.9.194
-botocore==1.12.194
+botocore==1.12.176  # puppet: nodownload
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -8,7 +8,7 @@ asn1crypto==0.24.0
 async_timeout==3.0.1
 attrs==19.1.0
 beetmoverscript==8.5.3  # puppet: nodownload
-boto3==1.9.194
+boto3==1.9.176  # puppet: nodownload
 botocore==1.12.176  # puppet: nodownload
 certifi==2019.6.16
 cffi==1.12.3

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -16,7 +16,7 @@ chardet==3.0.4
 click==7.0
 cryptography==2.7
 dictdiffer==0.8.0
-docutils==0.15.1.post1  # puppet: nodownload
+docutils==0.14  # puppet: nodownload
 frozendict==1.2
 github3.py==1.3.0
 idna==2.8

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -16,7 +16,7 @@ chardet==3.0.4
 click==7.0
 cryptography==2.7
 dictdiffer==0.8.0
-docutils==0.15.1.post1
+docutils==0.15.1.post1  # puppet: nodownload
 frozendict==1.2
 github3.py==1.3.0
 idna==2.8

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -8,15 +8,15 @@ asn1crypto==0.24.0
 async_timeout==3.0.1
 attrs==19.1.0
 beetmoverscript==8.5.3  # puppet: nodownload
-boto3==1.9.176  # puppet: nodownload
-botocore==1.12.176  # puppet: nodownload
+boto3==1.9.176  # pyup: ignore
+botocore==1.12.176  # pyup: ignore
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
 click==7.0
 cryptography==2.7
 dictdiffer==0.8.0
-docutils==0.14  # puppet: nodownload
+docutils==0.14  # pyup: ignore
 frozendict==1.2
 github3.py==1.3.0
 idna==2.8


### PR DESCRIPTION
The package name has `post1` in it, but evidently it's `0.15.1`:

`Requested docutils==0.15.1.post1 from https://files.pythonhosted.org/packages/d4/12/6c3fd74a590c7327c98cae008c11d536029fa9cd7924de477e8cb8804186/docutils-0.15.1-post1.tar.gz#sha256=f33ddb723332c6d6b6d99731ee1fc0c35eb4044a2df5cca1c64c8aa78eaf22cb, but installing version 0.15.1`

I think we either have to pin 0.14, or we can stop trying to download 0.15.1*. <s>This patch does the latter.</s> Tests are failing, so we're doing the former.