### PR TITLE
Revert "Pin pyparsing to 2.4.0 (#564)"

### DIFF
--- a/test/verify-requirements.sh
+++ b/test/verify-requirements.sh
@@ -13,7 +13,7 @@ apt-get -q --yes install gcc automake autoconf libmariadbclient-dev liblzma-dev
 
 # We need virtualenv and hashin to do our work, so we install them
 # into the system first
-pip install virtualenv pyparsing==2.4.0 hashin
+pip install virtualenv hashin
 
 error_messages=""
 


### PR DESCRIPTION
This reverts commit 185bf23f608fac22652d6eea25fd26afed273a7d, because pyparsing released 2.4.2 to squelch the warnings. See #564 for a link to their issue.