### PR TITLE
bug1561040 disabling collectd requires collectd

### DIFF
--- a/modules/collectd/manifests/disable.pp
+++ b/modules/collectd/manifests/disable.pp
@@ -5,6 +5,9 @@
 class collectd::disable {
     include collectd::settings
 
+    # collectd must be installed for the service to be stopped and disabled
+    include packages::collectd
+
     service {
         $collectd::settings::servicename:
             ensure     => stopped,


### PR DESCRIPTION
bsdpyN.tier3 missing collectd complained that the service could not be turned off because it did not exist

I worked-around the problem on those hosts manually by installing collectd, but we'll need this to avoid problems in the future when collectd is not installed.

instead of doing this, we could add an exec that checks for the service and only turns it off if it exists.