### PR TITLE
Bump scriptworker to 26.0.1

### DIFF
--- a/modules/addon_scriptworker/files/requirements.txt
+++ b/modules/addon_scriptworker/files/requirements.txt
@@ -29,7 +29,7 @@ python-dateutil==2.8.0
 python-jose==3.0.1
 requests==2.22.0
 rsa==4.0
-scriptworker==26.0.0
+scriptworker==26.0.1
 six==1.12.0
 slugid==2.0.0
 taskcluster==16.1.0

--- a/modules/balrog_scriptworker/files/requirements.txt
+++ b/modules/balrog_scriptworker/files/requirements.txt
@@ -35,7 +35,7 @@ pyrsistent==0.15.4
 python-dateutil==2.8.0
 redo==2.0.3
 requests==2.22.0
-scriptworker==26.0.0
+scriptworker==26.0.1
 six==1.12.0
 slugid==2.0.0
 taskcluster==16.1.0

--- a/modules/beetmover_scriptworker/files/requirements.txt
+++ b/modules/beetmover_scriptworker/files/requirements.txt
@@ -36,7 +36,7 @@ python-dateutil==2.8.0
 redo==2.0.3
 requests==2.22.0
 s3transfer==0.2.1
-scriptworker==26.0.0
+scriptworker==26.0.1
 six==1.12.0
 slugid==2.0.0
 taskcluster==16.1.0

--- a/modules/bouncer_scriptworker/files/requirements.txt
+++ b/modules/bouncer_scriptworker/files/requirements.txt
@@ -26,7 +26,7 @@ pycparser==2.19
 pyrsistent==0.15.4
 python-dateutil==2.8.0
 requests==2.22.0
-scriptworker==26.0.0
+scriptworker==26.0.1
 six==1.12.0
 slugid==2.0.0
 taskcluster==16.1.0

--- a/modules/pushapk_scriptworker/files/requirements.txt
+++ b/modules/pushapk_scriptworker/files/requirements.txt
@@ -64,7 +64,7 @@ python-dateutil==2.8.0
 pytz==2019.2
 requests==2.22.0
 rsa==4.0
-scriptworker==26.0.0
+scriptworker==26.0.1
 simplegeneric==0.8.1
 slugid==2.0.0
 taskcluster==16.1.0

--- a/modules/shipit_scriptworker/files/requirements.txt
+++ b/modules/shipit_scriptworker/files/requirements.txt
@@ -24,7 +24,7 @@ pyrsistent==0.15.4
 python-dateutil==2.8.0
 redo==2.0.3
 requests==2.22.0
-scriptworker==26.0.0
+scriptworker==26.0.1
 shipitapi==3.1.0
 shipitscript==4.0.0  # puppet: nodownload
 six==1.12.0

--- a/modules/signing_scriptworker/files/requirements.txt
+++ b/modules/signing_scriptworker/files/requirements.txt
@@ -36,7 +36,7 @@ python-jose==3.0.1
 requests==2.22.0
 requests-hawk==1.0.0
 rsa==4.0
-scriptworker==26.0.0
+scriptworker==26.0.1
 signingscript==11.1.0  # puppet: nodownload
 signtool==4.0.1
 six==1.12.0

--- a/modules/transparency_scriptworker/files/requirements.txt
+++ b/modules/transparency_scriptworker/files/requirements.txt
@@ -24,7 +24,7 @@ pyrsistent==0.15.4
 python-dateutil==2.8.0
 redo==2.0.3
 requests==2.22.0
-scriptworker==26.0.0
+scriptworker==26.0.1
 six==1.12.0
 slugid==2.0.0
 taskcluster==16.1.0

--- a/modules/tree_scriptworker/files/requirements.txt
+++ b/modules/tree_scriptworker/files/requirements.txt
@@ -25,7 +25,7 @@ pycparser==2.19
 pyrsistent==0.15.4
 python-dateutil==2.8.0
 requests==2.22.0
-scriptworker==26.0.0
+scriptworker==26.0.1
 six==1.12.0
 slugid==2.0.0
 taskcluster==16.1.0


### PR DESCRIPTION
Deploys https://github.com/mozilla-releng/scriptworker/pull/388

r? @rail because I read you're interested in knowing all the changes done to puppet while you're deploying the new workers on GCP. 