### PR TITLE
Adds signingscript configuration to sign fenix as fennec

### DIFF
--- a/modules/signing_scriptworker/templates/passwords-mobile.json.erb
+++ b/modules/signing_scriptworker/templates/passwords-mobile.json.erb
@@ -11,6 +11,9 @@
     "project:mobile:fenix:releng:signing:cert:production-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_fenix_release", "<%= scope.function_secret(["autograph_fenix_production_password"]) %>", ["autograph_apk"], "autograph"]
     ],
+    "project:mobile:fenix:releng:signing:cert:fennec-production-signing": [
+        ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_fennec_rel", "<%= scope.function_secret(["autograph_fennec_release_password"]) %>", ["autograph_apk"], "autograph"]
+    ],
     "project:mobile:reference-browser:releng:signing:cert:release-signing": [
         ["https://autograph-external.prod.autograph.services.mozaws.net", "signingscript_geckoview_reference_browser_rel", "<%= scope.function_secret(["autograph_reference_browser_prod_password"]) %>", ["autograph_apk_reference_browser"], "autograph"]
     ],


### PR DESCRIPTION
See [this Fenix ticket for context](https://github.com/mozilla-mobile/fenix/issues/4873).

I'll update the Fenix automation to produce a signing task with a payload like:
```
# scope: "project:mobile:fenix:releng:signing:format:autograph_apk_fennec_sha1"
# scope: "project:mobile:fenix:releng:signing:cert:fennec-production-signing"
{
  "upstreamArtifacts": [
    {
      "formats": [
        "autograph_apk_fennec_sha1"
      ],
      "paths": [...],
      "taskId": "...",
      "taskType": "build"
    }
  ]
}
```