### PR TITLE
taskcluster client+token change for migration TCW

### DIFF
--- a/modules/generic_worker/manifests/init.pp
+++ b/modules/generic_worker/manifests/init.pp
@@ -38,12 +38,12 @@ class generic_worker {
     case $::operatingsystem {
         Darwin: {
             if (has_aspect('staging')) {
-                $taskcluster_client_id = secret('osx_staging_client')
-                $taskcluster_access_token = hiera('osx_staging_client_token')
+                $taskcluster_client_id = secret('datacenter_gecko_t_osx_staging_client_id')
+                $taskcluster_access_token = hiera('datacenter_gecko_t_osx_staging_access_token')
             }
             else {
-                $taskcluster_client_id = secret('generic_worker_macosx_client_id')
-                $taskcluster_access_token = hiera('generic_worker_macosx_access_token')
+                $taskcluster_client_id = secret('datacenter_gecko_t_osx_client_id')
+                $taskcluster_access_token = hiera('datacenter_gecko_t_osx_access_token')
             }
             # The reboot command in OSX not have --force option
             $reboot_command = '/usr/bin/sudo /sbin/reboot'
@@ -89,12 +89,12 @@ class generic_worker {
             case $::operatingsystemrelease {
                 16.04: {
                     if (has_aspect('staging')) {
-                        $taskcluster_client_id = secret('generic_worker_linux_staging_client_id')
-                        $taskcluster_access_token = hiera('generic_worker_linux_staging_access_token')
+                        $taskcluster_client_id = secret('datacenter_gecko_t_linux_staging_client_id')
+                        $taskcluster_access_token = hiera('datacenter_gecko_t_linux_staging_access_token')
                     }
                     else {
-                        $taskcluster_client_id = secret('generic_worker_linux_client_id')
-                        $taskcluster_access_token = hiera('generic_worker_linux_access_token')
+                        $taskcluster_client_id = secret('datacenter_gecko_t_linux_client_id')
+                        $taskcluster_access_token = hiera('datacenter_gecko_t_linux_access_token')
                     }
 
                     # According to bug 1501936, https://bugzilla.mozilla.org/show_bug.cgi?id=1501936,Linux machines stuck at reboot process.

--- a/modules/generic_worker/templates/generic-worker.config.erb
+++ b/modules/generic_worker/templates/generic-worker.config.erb
@@ -18,7 +18,7 @@
   "publicIP": "<%= @ipaddress %>",
   "region": "",
   "requiredDiskSpaceMegabytes": 10240,
-  "rootURL": "https://taskcluster.net",
+  "rootURL": "https://firefox-ci-tc.services.mozilla.com",
   "runAfterUserCreation": "",
   "runTasksAsCurrentUser": true,
   "sentryProject": "generic-worker",


### PR DESCRIPTION
Changes needed for moving workers to the new TC service on Saturday, Nov 9th.

1. new rootUrl
2. swap client id+token for linux and macos prod+staging workers.

_This will be held and merged during the tree-closing-window._