### PR TITLE
Changes Fenix beta target track to "beta-closed"

### DIFF
--- a/modules/pushapk_scriptworker/manifests/settings.pp
+++ b/modules/pushapk_scriptworker/manifests/settings.pp
@@ -232,7 +232,7 @@ class pushapk_scriptworker::settings {
                             'package_names' => ['org.mozilla.fenix.beta'],
                             'certificate_alias' => 'fenix-beta',
                             'google' => {
-                                'default_track' => 'internal',
+                                'default_track' => 'beta-closed',
                                 'service_account' => $google_play_accounts['fenix-beta']['service_account'],
                                 'credentials_file' => "${root}/fenix_beta.p12",
                             }


### PR DESCRIPTION
This is for [this Fenix ticket](https://github.com/mozilla-mobile/fenix/issues/6461).
By changing `default_track` to `beta-closed`, releases will be pushed to the `beta-closed` track automatically