### PR TITLE
install zstandard pip for python 2 and 3

### DIFF
--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -5,10 +5,6 @@
 class packages::python2_zstandard {
     case $::operatingsystem {
         Ubuntu: {
-            package { 'zstd':
-                ensure => installed,
-            }
-
             package { 'python-pip':
                 ensure => installed,
             }

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -11,6 +11,7 @@ class packages::python2_zstandard {
 
             # BUG: on Puppet < 4, naming collision issue:
             #  https://tickets.puppetlabs.com/browse/PUP-1073
+            #  https://tickets.puppetlabs.com/browse/PUP-2313
             #  - can't use package to install zstandard for pip and pip3
 
             # BUG: on Puppet < 6, package with pip3 requires two runs to install

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -10,7 +10,7 @@ class packages::python2_zstandard {
             }
 
             # BUG: on Puppet < 5, naming collision issue:
-            #  https://projects.puppetlabs.com/issues/1398
+            #  https://tickets.puppetlabs.com/browse/PUP-1073
             #  - can't use package to install zstandard for pip and pip3
 
             # BUG: on Puppet < 6, package with pip3 requires two runs to install

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -10,9 +10,9 @@ class packages::python2_zstandard {
             }
 
             # BUG: on Puppet < 4, naming collision issue:
-            #  https://tickets.puppetlabs.com/browse/PUP-1073
-            #  https://tickets.puppetlabs.com/browse/PUP-2313
-            #  - can't use package to install zstandard for pip/py2 and pip3/py3
+            #   https://tickets.puppetlabs.com/browse/PUP-1073
+            #   https://tickets.puppetlabs.com/browse/PUP-2313
+            # - can't use package to install zstandard for pip/py2 and pip3/py3
 
             package { 'zstandard':
                 ensure   => '0.11.1',

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -2,14 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class packages::zstandard {
+class packages::python2_zstandard {
     case $::operatingsystem {
         Ubuntu: {
             package { 'zstd':
-                ensure => installed,
-            }
-
-            package { 'python3-pip':
                 ensure => installed,
             }
 
@@ -17,13 +13,14 @@ class packages::zstandard {
                 ensure => installed,
             }
 
-            # BUG: on Puppet < 6, this requires two runs to install
-            # https://tickets.puppetlabs.com/browse/PUP-7644
+            # BUG: on Puppet < 5, naming collision issue:
+            #  https://projects.puppetlabs.com/issues/1398
+            #  - can't use package to install zstandard for pip and pip3
+
             package { 'zstandard':
                 ensure   => '0.11.1',
-                name     => 'zstandard',
-                provider => ['pip', 'pip3'],
-                require  => [ Package['python-pip'], Package['python3-pip']]
+                provider => 'pip',
+                require  => Package['python-pip'],
             }
         }
         default: {

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -13,6 +13,9 @@ class packages::python2_zstandard {
             #  https://projects.puppetlabs.com/issues/1398
             #  - can't use package to install zstandard for pip and pip3
 
+            # BUG: on Puppet < 6, package with pip3 requires two runs to install
+            # https://tickets.puppetlabs.com/browse/PUP-7644
+
             package { 'zstandard':
                 ensure   => '0.11.1',
                 provider => 'pip',

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -9,7 +9,7 @@ class packages::python2_zstandard {
                 ensure => installed,
             }
 
-            # BUG: on Puppet < 5, naming collision issue:
+            # BUG: on Puppet < 4, naming collision issue:
             #  https://tickets.puppetlabs.com/browse/PUP-1073
             #  - can't use package to install zstandard for pip and pip3
 

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -12,10 +12,7 @@ class packages::python2_zstandard {
             # BUG: on Puppet < 4, naming collision issue:
             #  https://tickets.puppetlabs.com/browse/PUP-1073
             #  https://tickets.puppetlabs.com/browse/PUP-2313
-            #  - can't use package to install zstandard for pip and pip3
-
-            # BUG: on Puppet < 6, package with pip3 requires two runs to install
-            # https://tickets.puppetlabs.com/browse/PUP-7644
+            #  - can't use package to install zstandard for pip/py2 and pip3/py3
 
             package { 'zstandard':
                 ensure   => '0.11.1',

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -5,10 +5,6 @@
 class packages::python3_zstandard {
     case $::operatingsystem {
         Ubuntu: {
-            package { 'zstd':
-                ensure => installed,
-            }
-
             package { 'python3-pip':
                 ensure => installed,
             }

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -24,7 +24,7 @@ class packages::python3_zstandard {
             # }
 
             exec { 'install zstandard':
-                command => 'pip3 install zstandard==0.11.1',
+                command => '/usr/bin/pip3 install zstandard==0.11.1',
                 # TODO: avoid unecessary runs with unless
             }
         }

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -11,6 +11,7 @@ class packages::python3_zstandard {
 
             # BUG: on Puppet < 4, naming collision issue:
             #  https://tickets.puppetlabs.com/browse/PUP-1073
+            #  https://tickets.puppetlabs.com/browse/PUP-2313
             #  - can't use package to install zstandard for pip and pip3
 
             # BUG: on Puppet < 6, package with pip3 requires two runs to install

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -9,13 +9,22 @@ class packages::python3_zstandard {
                 ensure => installed,
             }
 
+            # BUG: on Puppet < 5, naming collision issue:
+            #  https://projects.puppetlabs.com/issues/1398
+            #  - can't use package to install zstandard for pip and pip3
+
             # BUG: on Puppet < 6, package with pip3 requires two runs to install
             # https://tickets.puppetlabs.com/browse/PUP-7644
 
-            package { 'zstandard':
-                ensure   => '0.11.1',
-                provider => 'pip3',
-                require  => Package['python3-pip'],
+            # package { 'zstandard':
+            #     ensure   => '0.11.1',
+            #     provider => 'pip3',
+            #     require  => Package['python3-pip'],
+            # }
+
+            exec { 'install zstandard':
+                command => 'pip3 install zstandard==0.11.1',
+                # TODO: avoid unecessary runs with unless
             }
         }
         default: {

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -12,7 +12,7 @@ class packages::python3_zstandard {
             # BUG: on Puppet < 4, naming collision issue:
             #  https://tickets.puppetlabs.com/browse/PUP-1073
             #  https://tickets.puppetlabs.com/browse/PUP-2313
-            #  - can't use package to install zstandard for pip and pip3
+            #  - can't use package to install zstandard for pip/py2 and pip3/py3
 
             # BUG: on Puppet < 6, package with pip3 requires two runs to install
             # https://tickets.puppetlabs.com/browse/PUP-7644

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::python3_zstandard {
+    case $::operatingsystem {
+        Ubuntu: {
+            package { 'zstd':
+                ensure => installed,
+            }
+
+            package { 'python3-pip':
+                ensure => installed,
+            }
+
+            # BUG: on Puppet < 6, package with pip3 requires two runs to install
+            # https://tickets.puppetlabs.com/browse/PUP-7644
+
+            package { 'zstandard':
+                ensure   => '0.11.1',
+                provider => 'pip3',
+                require  => Package['python3-pip'],
+            }
+        }
+        default: {
+            fail("Cannot install on ${::operatingsystem}")
+        }
+    }
+}

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -9,7 +9,7 @@ class packages::python3_zstandard {
                 ensure => installed,
             }
 
-            # BUG: on Puppet < 5, naming collision issue:
+            # BUG: on Puppet < 4, naming collision issue:
             #  https://tickets.puppetlabs.com/browse/PUP-1073
             #  - can't use package to install zstandard for pip and pip3
 

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -10,12 +10,12 @@ class packages::python3_zstandard {
             }
 
             # BUG: on Puppet < 4, naming collision issue:
-            #  https://tickets.puppetlabs.com/browse/PUP-1073
-            #  https://tickets.puppetlabs.com/browse/PUP-2313
-            #  - can't use package to install zstandard for pip/py2 and pip3/py3
+            #   https://tickets.puppetlabs.com/browse/PUP-1073
+            #   https://tickets.puppetlabs.com/browse/PUP-2313
+            # - can't use package to install zstandard for pip/py2 and pip3/py3
 
             # BUG: on Puppet < 6, package with pip3 requires two runs to install
-            # https://tickets.puppetlabs.com/browse/PUP-7644
+            #   https://tickets.puppetlabs.com/browse/PUP-7644
 
             # package { 'zstandard':
             #     ensure   => '0.11.1',

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -10,7 +10,7 @@ class packages::python3_zstandard {
             }
 
             # BUG: on Puppet < 5, naming collision issue:
-            #  https://projects.puppetlabs.com/issues/1398
+            #  https://tickets.puppetlabs.com/browse/PUP-1073
             #  - can't use package to install zstandard for pip and pip3
 
             # BUG: on Puppet < 6, package with pip3 requires two runs to install

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -17,21 +17,14 @@ class packages::zstandard {
                 ensure => installed,
             }
 
+            # BUG: on Puppet < 6, this requires two runs to install
+            # https://tickets.puppetlabs.com/browse/PUP-7644
             package { 'zstandard':
                 ensure   => '0.11.1',
                 name     => 'zstandard',
                 provider => ['pip', 'pip3'],
                 require  => Package['python-pip'],
             }
-
-            # BUG: on Puppet < 6, this requires two runs to install 
-            # https://tickets.puppetlabs.com/browse/PUP-7644
-            # package { 'zstandard-py3':
-            #     ensure   => '0.11.1',
-            #     name     => 'zstandard',
-            #     provider => 'pip3',
-            #     require  => Package['python3-pip'],
-            # }
         }
         default: {
             fail("Cannot install on ${::operatingsystem}")

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -17,21 +17,21 @@ class packages::zstandard {
                 ensure => installed,
             }
 
-            package { 'zstandard-py2':
+            package { 'zstandard':
                 ensure   => '0.11.1',
                 name     => 'zstandard',
-                provider => 'pip',
+                provider => ['pip', 'pip3'],
                 require  => Package['python-pip'],
             }
 
             # BUG: on Puppet < 6, this requires two runs to install 
             # https://tickets.puppetlabs.com/browse/PUP-7644
-            package { 'zstandard-py3':
-                ensure   => '0.11.1',
-                name     => 'zstandard',
-                provider => 'pip3',
-                require  => Package['python3-pip'],
-            }
+            # package { 'zstandard-py3':
+            #     ensure   => '0.11.1',
+            #     name     => 'zstandard',
+            #     provider => 'pip3',
+            #     require  => Package['python3-pip'],
+            # }
         }
         default: {
             fail("Cannot install on ${::operatingsystem}")

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -17,7 +17,7 @@ class packages::zstandard {
                 ensure => installed,
             }
 
-            package { 'zstandard@2':
+            package { 'zstandard-py2':
                 ensure   => '0.11.1',
                 name     => 'zstandard',
                 provider => 'pip',
@@ -26,7 +26,7 @@ class packages::zstandard {
 
             # BUG: on Puppet < 6, this requires two runs to install 
             # https://tickets.puppetlabs.com/browse/PUP-7644
-            package { 'zstandard@3':
+            package { 'zstandard-py3':
                 ensure   => '0.11.1',
                 name     => 'zstandard',
                 provider => 'pip3',

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -23,7 +23,7 @@ class packages::zstandard {
                 ensure   => '0.11.1',
                 name     => 'zstandard',
                 provider => ['pip', 'pip3'],
-                require  => Package['python-pip'],
+                require  => [ Package['python-pip'], Package['python3-pip']]
             }
         }
         default: {

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::zstamdard {
+    case $::operatingsystem {
+        Ubuntu: {
+            package { ['zstd']:
+                ensure => installed,
+            }
+
+            package { ['python3-pip']:
+                ensure => installed,
+            }
+
+            package { ['python-pip']:
+                ensure => installed,
+            }
+
+            package { 'zstandard@2':
+                ensure   => '0.11.1',
+                name     => 'zstandard',
+                provider => 'pip',
+                require  => Package['python-pip'],
+            }
+
+            # BUG: on Puppet < 6, this requires two runs to install 
+            # https://tickets.puppetlabs.com/browse/PUP-7644
+            package { 'zstandard@3':
+                ensure   => '0.11.1',
+                name     => 'zstandard',
+                provider => 'pip3',
+                require  => Package['python3-pip'],
+            }
+        }
+        default: {
+            fail("Cannot install on ${::operatingsystem}")
+        }
+    }
+}

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -5,15 +5,15 @@
 class packages::zstamdard {
     case $::operatingsystem {
         Ubuntu: {
-            package { ['zstd']:
+            package { 'zstd':
                 ensure => installed,
             }
 
-            package { ['python3-pip']:
+            package { 'python3-pip':
                 ensure => installed,
             }
 
-            package { ['python-pip']:
+            package { 'python-pip':
                 ensure => installed,
             }
 

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class packages::zstamdard {
+class packages::zstandard {
     case $::operatingsystem {
         Ubuntu: {
             package { 'zstd':

--- a/modules/packages/manifests/zstd.pp
+++ b/modules/packages/manifests/zstd.pp
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::zstd {
+    case $::operatingsystem {
+        Ubuntu: {
+            package { 'zstd':
+                ensure => installed,
+            }
+        }
+        default: {
+            fail("Cannot install on ${::operatingsystem}")
+        }
+    }
+}

--- a/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
+++ b/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
@@ -19,7 +19,9 @@ class toplevel::worker::releng::generic_worker::test inherits toplevel::worker::
     case $::operatingsystem {
         'Ubuntu': {
             include packages::mozilla::google_chrome
-            include packages::zstandard
+            include packages::zstd
+            include packages::python2-zstandard
+            include packages::python3-zstandard
             include nrpe
             include nrpe::check::puppet_agent
             include nrpe::check::ntp_time

--- a/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
+++ b/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
@@ -7,7 +7,6 @@ class toplevel::worker::releng::generic_worker::test inherits toplevel::worker::
     include vnc
     include ntp::daemon
     include packages::mozilla::python3
-    include packages::zstandard
     include dirs::builds::hg_shared
     include dirs::builds::git_shared
     include dirs::builds::tooltool_cache
@@ -20,6 +19,7 @@ class toplevel::worker::releng::generic_worker::test inherits toplevel::worker::
     case $::operatingsystem {
         'Ubuntu': {
             include packages::mozilla::google_chrome
+            include packages::zstandard
             include nrpe
             include nrpe::check::puppet_agent
             include nrpe::check::ntp_time

--- a/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
+++ b/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
@@ -20,8 +20,8 @@ class toplevel::worker::releng::generic_worker::test inherits toplevel::worker::
         'Ubuntu': {
             include packages::mozilla::google_chrome
             include packages::zstd
-            include packages::python2-zstandard
-            include packages::python3-zstandard
+            include packages::python2_zstandard
+            include packages::python3_zstandard
             include nrpe
             include nrpe::check::puppet_agent
             include nrpe::check::ntp_time

--- a/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
+++ b/modules/toplevel/manifests/worker/releng/generic_worker/test.pp
@@ -7,6 +7,7 @@ class toplevel::worker::releng::generic_worker::test inherits toplevel::worker::
     include vnc
     include ntp::daemon
     include packages::mozilla::python3
+    include packages::zstandard
     include dirs::builds::hg_shared
     include dirs::builds::git_shared
     include dirs::builds::tooltool_cache


### PR DESCRIPTION
Also installs zstd CLI utility.

known issues:
- puppet < 4 doesn't support the same package name with two different providers, so exec must be used.

Testing done:
- converges locally in docker container
- converged successfully on t-linux64-ms-314 and t-linux64-ms-315
`puppet agent --test --server=releng-puppet2.srv.releng.mdc1.mozilla.com --environment=aerickson`