### PR TITLE
add pids to syslog msg for ubuntu

### DIFF
--- a/modules/log_aggregator/templates/client.conf.erb
+++ b/modules/log_aggregator/templates/client.conf.erb
@@ -5,10 +5,5 @@
 # forward all syslog data to the aggregation server 
 # (via TCP because of the second @)
 
-# add PID into msg because papertrail doesn't show it
-$SystemLogUsePIDFromSystem on
-$template PIDInMsgTemplate, "<%pri%>%timestamp% %hostname% %syslogtag% [%syslogtag:R,ERE,1,BLANK,0:\[([0-9]{1,5})\]--end%]%msg%\n"
-$ActionForwardDefaultTemplate PIDInMsgTemplate
-
 *.* @@<%= @log_aggregator %>:<%= @logging_port %>
 

--- a/modules/log_aggregator/templates/client.conf.erb
+++ b/modules/log_aggregator/templates/client.conf.erb
@@ -5,5 +5,10 @@
 # forward all syslog data to the aggregation server 
 # (via TCP because of the second @)
 
+# add PID into msg because papertrail doesn't show it
+$SystemLogUsePIDFromSystem on
+$template PIDInMsgTemplate, "<%pri%>%timestamp% %hostname% %syslogtag% [%syslogtag:R,ERE,1,BLANK,0:\[([0-9]{1,5})\]--end%]%msg%\n"
+$ActionForwardDefaultTemplate PIDInMsgTemplate
+
 *.* @@<%= @log_aggregator %>:<%= @logging_port %>
 

--- a/modules/log_aggregator/templates/ubuntu_client.conf.erb
+++ b/modules/log_aggregator/templates/ubuntu_client.conf.erb
@@ -8,7 +8,7 @@
 
 # add PID into msg because papertrail doesn't show it
 $SystemLogUsePIDFromSystem on
-$template PIDInMsgTemplate, "<%pri%>%timestamp% %hostname% %syslogtag% [%syslogtag:R,ERE,1,BLANK,0:\[([0-9]{1,5})\]--end%]%msg%\n"
+$template PIDInMsgTemplate, "<%%pri%>%timestamp% %hostname% %syslogtag% [%syslogtag:R,ERE,1,BLANK,0:\[([0-9]{1,5})\]--end%]%msg%\n"
 $ActionForwardDefaultTemplate PIDInMsgTemplate
 
 # forward all syslog data to the aggregation server

--- a/modules/log_aggregator/templates/ubuntu_client.conf.erb
+++ b/modules/log_aggregator/templates/ubuntu_client.conf.erb
@@ -6,6 +6,11 @@
 :msg, contains, "EDAC MC0: 1 UE ie31200 UE on mc#0csrow#3channel#0 (csrow:3 channel:0 page:0x0 offset:0x0 grain:8)" stop
 :msg, contains, "EDAC MC0: 1 UE ie31200 UE on mc#0csrow#3channel#1 (csrow:3 channel:1 page:0x0 offset:0x0 grain:8)" stop
 
+# add PID into msg because papertrail doesn't show it
+$SystemLogUsePIDFromSystem on
+$template PIDInMsgTemplate, "<%pri%>%timestamp% %hostname% %syslogtag% [%syslogtag:R,ERE,1,BLANK,0:\[([0-9]{1,5})\]--end%]%msg%\n"
+$ActionForwardDefaultTemplate PIDInMsgTemplate
+
 # forward all syslog data to the aggregation server
 # (via TCP because of the second @)
 # Bug 1410207: via UDP as workaround. TCP resulting in zero-length msg


### PR DESCRIPTION
Papertrail does not show pids from incoming syslog entries. Security requested pids in the logs. So we can add the pid into the msg body for each.

This adds the pids into the message body for the linux64 workers.