### PR TITLE
Bug 1614420: invalidate the use of the aws puppetmasters

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -53,8 +53,6 @@ class config inherits config::base {
                           'releng-puppet2.srv.releng.mdc1.mozilla.com',
                           'releng-puppet1.srv.releng.mdc2.mozilla.com',
                           'releng-puppet2.srv.releng.mdc2.mozilla.com',
-                          'releng-puppet1.srv.releng.use1.mozilla.com',
-                          'releng-puppet1.srv.releng.usw2.mozilla.com',
                         ]
 
     $local_datacenter = $::fqdn ? {


### PR DESCRIPTION
This will cause any puppet agent currently signed with one of the AWS puppetmasters to renew their agent certificate with different puppetmaster in the datacenters.  Which means the agent won't fail when the AWS puppetmaster intermediate certificate expires.  If we decide to renew/replace the puppetmasters intermediate CA, we can add them back to the list and they will become valid CAs to issue agent certificates again.