### PR TITLE
google chrome v80 on linux64

### DIFF
--- a/modules/packages/manifests/mozilla/google_chrome.pp
+++ b/modules/packages/manifests/mozilla/google_chrome.pp
@@ -16,7 +16,7 @@ class packages::mozilla::google_chrome {
                     Anchor['packages::mozilla::google_chrome::begin'] ->
                     package {
                         'google-chrome-stable':
-                            ensure => '79.0.3945.117-1';
+                            ensure => '80.0.3987.106-1';
                     } -> Anchor['packages::mozilla::google_chrome::end']
                 }
                 default: {

--- a/modules/packages/manifests/setup.pp
+++ b/modules/packages/manifests/setup.pp
@@ -234,7 +234,7 @@ class packages::setup {
             }
             # to flush the package index, increase this value by one (or
             # anything, really, just change it).
-            $repoflag = 52
+            $repoflag = 53
             file {
                 '/etc/.repo-flag':
                     content =>


### PR DESCRIPTION
*do not merge* (waiting on chromedriver changes)
running on "staging" group "-beta" for verification by qa team

```
[root@t-linux64-ms-444 ~]# /opt/google/chrome/chrome --version
Google Chrome 79.0.3945.117 unknown
[root@t-linux64-ms-444 ~]# puppet agent --test --server releng-puppet2.srv.releng.mdc1.mozilla.com --environment dhouse
Info: Retrieving pluginfacts
[...]
[root@t-linux64-ms-444 ~]# /opt/google/chrome/chrome --version
Google Chrome 80.0.3987.106 unknown
```