### PR TITLE
Begin redirecting AWS puppet agents and logs

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -35,10 +35,12 @@ class config inherits config::base {
             'releng-puppet2.srv.releng.mdc2.mozilla.com',
         ],
         '.*\.releng\.use1\.mozilla\.com' => [
-            'releng-puppet1.srv.releng.use1.mozilla.com',
+            'releng-puppet1.srv.releng.mdc1.mozilla.com',
+            'releng-puppet2.srv.releng.mdc1.mozilla.com',
         ],
         '.*\.releng\.usw2\.mozilla\.com' => [
-            'releng-puppet1.srv.releng.usw2.mozilla.com',
+            'releng-puppet1.srv.releng.mdc1.mozilla.com',
+            'releng-puppet2.srv.releng.mdc1.mozilla.com',
         ],
     }
 
@@ -307,16 +309,13 @@ class config inherits config::base {
     $log_aggregator    = $::fqdn ? {
         /.*\.mdc1\.mozilla\.com/ => 'log-aggregator.srv.releng.mdc1.mozilla.com',
         /.*\.mdc2\.mozilla\.com/ => 'log-aggregator.srv.releng.mdc2.mozilla.com',
-        /.*\.use1\.mozilla\.com/ => 'log-aggregator.srv.releng.use1.mozilla.com',
-        /.*\.usw2\.mozilla\.com/ => 'log-aggregator.srv.releng.usw2.mozilla.com',
-        default => '',
+        default => 'log-aggregator.srv.releng.mdc1.mozilla.com',
     }
 
     # we need to pick a logging port > 1024 for AWS to use the ELB
     $logging_port = $::fqdn ? {
         /.*\.(mdc1|mdc2)\.mozilla\.com/ => '514',
-        /.*\.(usw2|use1)\.mozilla\.com/ => '1514',
-        default => '',
+        default => '514',
     }
 
     #### end configuration information for rsyslog logging

--- a/modules/fw/manifests/profiles/log_aggregator.pp
+++ b/modules/fw/manifests/profiles/log_aggregator.pp
@@ -5,17 +5,10 @@
 class fw::profiles::log_aggregator {
 
     case $::fqdn {
-        /.*\.mdc1\.mozilla\.com/: {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
             include ::fw::roles::ssh_from_rejh_logging
             include ::fw::roles::nrpe_from_nagios
-            include ::fw::roles::syslog_from_mdc1_releng
-            include ::fw::roles::syslog_from_mtv2_qa
-        }
-        /.*\.mdc2\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
-            include ::fw::roles::nrpe_from_nagios
-            include ::fw::roles::syslog_from_mdc2_releng
-            include ::fw::roles::syslog_from_mtv2_qa
+            include ::fw::roles::syslog_from_anywhere
         }
         default:{
             # Silently skip other DCs

--- a/modules/fw/manifests/roles/syslog_from_anywhere.pp
+++ b/modules/fw/manifests/roles/syslog_from_anywhere.pp
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::syslog_from_anywhere {
+    include fw::networks
+
+    fw::rules { 'allow_syslog_udp_from_anywhere':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'syslog_udp'
+    }
+    fw::rules { 'allow_syslog_tcp_from_anywhere':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'syslog_tcp'
+    }
+}


### PR DESCRIPTION
        This redirects the hosts in AWS (if any) to use mdc1/2 for
        puppetmasters and log aggregation in preperation of
        decommisioning AWS releng puppetagain infra.