### PR TITLE
Bug 1620424: remove mdc1 puppetmasters are valid CA issuers

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -51,8 +51,6 @@ class config inherits config::base {
 
     # Puppet masters CAs we deem valid
     $valid_puppet_cas = [
-                          'releng-puppet1.srv.releng.mdc1.mozilla.com',
-                          'releng-puppet2.srv.releng.mdc1.mozilla.com',
                           'releng-puppet1.srv.releng.mdc2.mozilla.com',
                           'releng-puppet2.srv.releng.mdc2.mozilla.com',
                         ]


### PR DESCRIPTION
This remove the mdc1 puppetmasters from the valid puppet CA list which will cause all agents with certs issued from these hosts to renew their certs with one of the mdc2 hosts.  Once the mdc1 puppet masters have new CA certs, we can add them back.