### PR TITLE
Bug 1620424: add mdc1 puppetmaster back to valid CA list

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -51,6 +51,8 @@ class config inherits config::base {
 
     # Puppet masters CAs we deem valid
     $valid_puppet_cas = [
+                          'releng-puppet1.srv.releng.mdc1.mozilla.com',
+                          'releng-puppet2.srv.releng.mdc1.mozilla.com',
                           'releng-puppet1.srv.releng.mdc2.mozilla.com',
                           'releng-puppet2.srv.releng.mdc2.mozilla.com',
                         ]


### PR DESCRIPTION
MDC1 puppetmasters have new intermediate CA certs/keys and new master leaf certs/keys.  This will add them back to the vaild_puppet_cas list so agents can renew their certs more distributively among the puppetmaster CAs.