### PR TITLE
linux on moonshot - add google chrome repo and schedule check+update weekly

### DIFF
--- a/modules/packages/files/google-chrome.list
+++ b/modules/packages/files/google-chrome.list
@@ -1,0 +1,3 @@
+### THIS FILE IS AUTOMATICALLY CONFIGURED ###
+# You may comment out this entry, but any other modifications may be lost.
+deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main

--- a/modules/packages/manifests/mozilla/google_chrome.pp
+++ b/modules/packages/manifests/mozilla/google_chrome.pp
@@ -24,7 +24,7 @@ class packages::mozilla::google_chrome {
                     }
                     exec { 'update-chrome-action':
                         schedule => 'update-chrome-schedule',
-                        command => '/usr/bin/apt-get update -o Dir::Etc::sourcelist="sources.list.d/google-chrome.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"',
+                        command  => '/usr/bin/apt-get update -o Dir::Etc::sourcelist="sources.list.d/google-chrome.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"',
                     }
                     package {
                         'google-chrome-stable':

--- a/modules/packages/manifests/mozilla/google_chrome.pp
+++ b/modules/packages/manifests/mozilla/google_chrome.pp
@@ -14,9 +14,21 @@ class packages::mozilla::google_chrome {
             case $::operatingsystemrelease {
                 16.04: {
                     Anchor['packages::mozilla::google_chrome::begin'] ->
+                    file {
+                        '/etc/apt/sources.list.d/google-chrome.list':
+                            source => 'puppet:///modules/packages/google-chrome.list',
+                    }
+                    schedule { 'update-chrome-schedule':
+                        period => weekly,
+                        repeat => 1,
+                    }
+                    exec { 'update-chrome-action':
+                        schedule => 'update-chrome-schedule',
+                        command => '/usr/bin/apt-get update -o Dir::Etc::sourcelist="sources.list.d/google-chrome.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"',
+                    }
                     package {
                         'google-chrome-stable':
-                            ensure => '81.0.4044.129-1';
+                            ensure => latest;
                     } -> Anchor['packages::mozilla::google_chrome::end']
                 }
                 default: {


### PR DESCRIPTION
This is the repo file that chrome creates. I've put it into puppet to ensure puppet does not nuke it.

The at-least once weekly (when puppet is run) schedule is not ideal but will run less randomly than keystone :smiling_imp: _and_ not during tasks.