### PR TITLE
remove linux -dev pool

### DIFF
--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -157,20 +157,3 @@ node 't-linux64-ms-280.test.releng.mdc1.mozilla.com',
     include toplevel::worker::releng::generic_worker::test::gpu
 }
 
-node 't-linux64-ms-141.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-142.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-143.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-144.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-145.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-146.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-147.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-148.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-149.test.releng.mdc1.mozilla.com',
-    't-linux64-ms-150.test.releng.mdc1.mozilla.com' {
-    $aspects          = [ 'low-security' ]
-    $slave_trustlevel = 'try'
-    $worker_type = "gecko-t-linux-talos-dev"
-    include fw::profiles::linux_taskcluster_worker
-    include toplevel::worker::releng::generic_worker::test::gpu
-}
-


### PR DESCRIPTION
The -dev pool has not been used. We can re-create it when needed. https://bugzilla.mozilla.org/show_bug.cgi?id=1653992