### PR TITLE
Invalidate mdc2 puppetmaster cas

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -53,8 +53,6 @@ class config inherits config::base {
     $valid_puppet_cas = [
                           'releng-puppet1.srv.releng.mdc1.mozilla.com',
                           'releng-puppet2.srv.releng.mdc1.mozilla.com',
-                          'releng-puppet1.srv.releng.mdc2.mozilla.com',
-                          'releng-puppet2.srv.releng.mdc2.mozilla.com',
                         ]
 
     $local_datacenter = $::fqdn ? {


### PR DESCRIPTION
This PR will cause any puppet agents with mdc2 puppet masters as their intermediate CA master to renew their agent cert with another valid CA, in this case either of the MDC1 puppet masters. It does not disable or prevent the agent from using either of the MDC2 puppet masters.  The purpose of this is ensure no agents are issued certs from a puppet master that may be turned off soon.  This includes MDC1 agents that may currently be issued certs from MDC2 intermediate CAs.