### PR TITLE
Allow access to hosts without using jumphost

### DIFF
--- a/modules/fw/manifests/profiles/bsdpy.pp
+++ b/modules/fw/manifests/profiles/bsdpy.pp
@@ -6,12 +6,12 @@ class fw::profiles::bsdpy {
 
     case $::fqdn {
         /.*\.mdc1\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::bsdpy_from_mdc1_releng
         }
         /.*\.mdc2\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::bsdpy_from_mdc2_releng
         }

--- a/modules/fw/manifests/profiles/deploystudio.pp
+++ b/modules/fw/manifests/profiles/deploystudio.pp
@@ -6,15 +6,15 @@ class fw::profiles::deploystudio {
 
     case $::fqdn {
         /.*\.mdc1\.mozilla\.com/: {
-            include ::fw::roles::vnc_from_rejh_logging
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::vnc_from_anywhere_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::bacula_from_mdc1_bacula_host
             include ::fw::roles::deploystudio_from_mdc1_releng
         }
         /.*\.mdc2\.mozilla\.com/: {
-            include ::fw::roles::vnc_from_rejh_logging
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::vnc_from_anywhere_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::bacula_from_mdc1_bacula_host
             include ::fw::roles::bacula_from_mdc2_bacula_host

--- a/modules/fw/manifests/profiles/depsigning.pp
+++ b/modules/fw/manifests/profiles/depsigning.pp
@@ -6,7 +6,7 @@ class fw::profiles::depsigning {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::dep_signing_from_anywhere
             include ::fw::roles::nrpe_from_nagios
         }

--- a/modules/fw/manifests/profiles/distinguished_puppetmaster.pp
+++ b/modules/fw/manifests/profiles/distinguished_puppetmaster.pp
@@ -10,7 +10,7 @@ class fw::profiles::distinguished_puppetmaster {
 
             include ::fw::roles::puppetmaster_from_all_releng
             include ::fw::roles::puppetmaster_sync_from_all_puppetmasters
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
         }
         /.*\.mdc2\.mozilla\.com/: {
@@ -18,7 +18,7 @@ class fw::profiles::distinguished_puppetmaster {
             include ::fw::roles::bacula_from_mdc2_bacula_host
             include ::fw::roles::puppetmaster_from_all_releng
             include ::fw::roles::puppetmaster_sync_from_all_puppetmasters
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
         }
         default: {

--- a/modules/fw/manifests/profiles/linux_taskcluster_worker.pp
+++ b/modules/fw/manifests/profiles/linux_taskcluster_worker.pp
@@ -7,8 +7,8 @@ class fw::profiles::linux_taskcluster_worker {
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
             include ::fw::roles::nrpe_from_nagios
-            include ::fw::roles::vnc_from_rejh_logging
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::vnc_from_anywhere_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::ssh_from_roller
         }
         default:{

--- a/modules/fw/manifests/profiles/log_aggregator.pp
+++ b/modules/fw/manifests/profiles/log_aggregator.pp
@@ -6,7 +6,7 @@ class fw::profiles::log_aggregator {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::syslog_from_anywhere
         }

--- a/modules/fw/manifests/profiles/mac_depsigning.pp
+++ b/modules/fw/manifests/profiles/mac_depsigning.pp
@@ -6,7 +6,7 @@ class fw::profiles::mac_depsigning {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::dep_signing_from_osx
         }

--- a/modules/fw/manifests/profiles/mac_signing.pp
+++ b/modules/fw/manifests/profiles/mac_signing.pp
@@ -6,7 +6,7 @@ class fw::profiles::mac_signing {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::dep_signing_from_osx
             include ::fw::roles::rel_signing_from_osx

--- a/modules/fw/manifests/profiles/osx_taskcluster_worker.pp
+++ b/modules/fw/manifests/profiles/osx_taskcluster_worker.pp
@@ -7,8 +7,8 @@ class fw::profiles::osx_taskcluster_worker {
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
             include ::fw::roles::nrpe_from_nagios
-            include ::fw::roles::vnc_from_rejh_logging
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::vnc_from_anywhere_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::ssh_from_roller
         }
         default:{

--- a/modules/fw/manifests/profiles/partner_repack.pp
+++ b/modules/fw/manifests/profiles/partner_repack.pp
@@ -6,9 +6,9 @@ class fw::profiles::partner_repack {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
-            include ::fw::roles::vnc_from_rejh_logging
+            include ::fw::roles::vnc_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
         }
         default:{
             # Silently skip other DCs

--- a/modules/fw/manifests/profiles/puppetmasters.pp
+++ b/modules/fw/manifests/profiles/puppetmasters.pp
@@ -7,7 +7,7 @@ class fw::profiles::puppetmasters {
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
             include ::fw::roles::puppetmaster_from_all_releng
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
         }
         default:{

--- a/modules/fw/manifests/profiles/roller.pp
+++ b/modules/fw/manifests/profiles/roller.pp
@@ -6,7 +6,7 @@ class fw::profiles::roller {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::roller_api_from_anywhere
         }

--- a/modules/fw/manifests/profiles/signing.pp
+++ b/modules/fw/manifests/profiles/signing.pp
@@ -6,7 +6,7 @@ class fw::profiles::signing {
 
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
             include ::fw::roles::dep_signing_from_linux
             include ::fw::roles::rel_signing_from_linux

--- a/modules/fw/manifests/profiles/taskcluster_host_secrets.pp
+++ b/modules/fw/manifests/profiles/taskcluster_host_secrets.pp
@@ -7,7 +7,7 @@ class fw::profiles::taskcluster_host_secrets {
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
             include ::fw::roles::taskcluster_host_secrets_from_dc_test
-            include ::fw::roles::ssh_from_rejh_logging
+            include ::fw::roles::ssh_from_anywhere_logging
             include ::fw::roles::nrpe_from_nagios
         }
         default:{


### PR DESCRIPTION
In preparation of decommissioning the releng jumphosts, this PR allows ssh/vnc access directly from the corp vpn/jumphosts.  It covers all the hosts still managed under puppetagain.